### PR TITLE
docs: add mkdocs, mkdocs-material and fix docstring examples

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,76 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'src/unwrappy/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'src/unwrappy/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install system dependencies for social cards
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
+
+      - name: Install dependencies
+        run: |
+          uv sync --group docs
+
+      - name: Build documentation
+        run: |
+          uv run mkdocs build --strict
+
+      - name: Upload artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,21 +1,15 @@
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo.svg">
-    <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-dark.svg">
-    <img alt="unwrappy" src="docs/assets/logo-dark.svg" width="80">
-  </picture>
-</p>
-
-<p align="center">
-  <a href="https://pypi.org/project/unwrappy/"><img src="https://img.shields.io/pypi/v/unwrappy" alt="PyPI"></a>
-  <a href="https://pypi.org/project/unwrappy/"><img src="https://img.shields.io/pypi/pyversions/unwrappy" alt="Python"></a>
-  <a href="https://github.com/leodiegues/unwrappy/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License"></a>
-  <a href="https://github.com/leodiegues/unwrappy/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/leodiegues/unwrappy/test.yml?label=tests" alt="Tests"></a>
-  <a href="https://leodiegues.github.io/unwrappy"><img src="https://img.shields.io/github/actions/workflow/status/leodiegues/unwrappy/docs.yml?label=docs" alt="Docs"></a>
-  <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
-</p>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo.svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-dark.svg">
+  <img alt="unwrappy" src="docs/assets/logo-dark.svg" width="80">
+</picture>
 
 # unwrappy
+
+[![PyPI](https://img.shields.io/pypi/v/unwrappy?style=for-the-badge&colorA=d2ccb8&colorB=423e31)](https://pypi.org/project/unwrappy/)
+[![Python](https://img.shields.io/pypi/pyversions/unwrappy?style=for-the-badge&colorA=d2ccb8&colorB=423e31)](https://pypi.org/project/unwrappy/)
+[![License](https://img.shields.io/badge/license-MIT-423e31?style=for-the-badge&colorA=d2ccb8&colorB=423e31)](https://github.com/leodiegues/unwrappy/blob/main/LICENSE)
+[![Tests](https://img.shields.io/github/actions/workflow/status/leodiegues/unwrappy/test.yml?label=tests&style=for-the-badge&colorA=d2ccb8&colorB=423e31)](https://github.com/leodiegues/unwrappy/actions/workflows/test.yml)
 
 Rust-inspired `Result` and `Option` types for Python, enabling safe, expressive error handling with errors as values.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-dark.svg">
+    <img alt="unwrappy" src="docs/assets/logo-dark.svg" width="80">
+  </picture>
+</p>
+
+<p align="center">
+  <a href="https://pypi.org/project/unwrappy/"><img src="https://img.shields.io/pypi/v/unwrappy" alt="PyPI"></a>
+  <a href="https://pypi.org/project/unwrappy/"><img src="https://img.shields.io/pypi/pyversions/unwrappy" alt="Python"></a>
+  <a href="https://github.com/leodiegues/unwrappy/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License"></a>
+  <a href="https://github.com/leodiegues/unwrappy/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/leodiegues/unwrappy/test.yml?label=tests" alt="Tests"></a>
+  <a href="https://leodiegues.github.io/unwrappy"><img src="https://img.shields.io/github/actions/workflow/status/leodiegues/unwrappy/docs.yml?label=docs" alt="Docs"></a>
+  <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
+</p>
+
 # unwrappy
 
 Rust-inspired `Result` and `Option` types for Python, enabling safe, expressive error handling with errors as values.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,86 @@
+# API Reference
+
+Complete API documentation for unwrappy, auto-generated from source code docstrings.
+
+## Modules
+
+<div class="grid cards" markdown>
+
+-   :material-check-circle:{ .lg .middle } **Result**
+
+    ---
+
+    The `Result[T, E]` type and related classes for error handling.
+
+    - `Ok[T]` - Success variant
+    - `Err[E]` - Error variant
+    - `LazyResult[T, E]` - Deferred execution
+    - Utility functions
+
+    [:octicons-arrow-right-24: Result API](result.md)
+
+-   :material-help-circle:{ .lg .middle } **Option**
+
+    ---
+
+    The `Option[T]` type and related classes for optional values.
+
+    - `Some[T]` - Present variant
+    - `Nothing` - Absent variant
+    - `LazyOption[T]` - Deferred execution
+    - Utility functions
+
+    [:octicons-arrow-right-24: Option API](option.md)
+
+</div>
+
+## Quick Reference
+
+### Result Types
+
+| Type | Description |
+|------|-------------|
+| `Result[T, E]` | Type alias for `Ok[T] \| Err[E]` |
+| `Ok[T]` | Success variant containing a value |
+| `Err[E]` | Error variant containing an error |
+| `LazyResult[T, E]` | Deferred Result computation |
+
+### Option Types
+
+| Type | Description |
+|------|-------------|
+| `Option[T]` | Type alias for `Some[T] \| Nothing` |
+| `Some[T]` | Present variant containing a value |
+| `Nothing` | Absent variant (singleton type) |
+| `NOTHING` | The Nothing singleton instance |
+| `LazyOption[T]` | Deferred Option computation |
+
+### Exceptions
+
+| Exception | Description |
+|-----------|-------------|
+| `UnwrapError` | Raised when unwrapping fails |
+| `ChainedError` | Error with context chain |
+
+### Utility Functions
+
+| Function | Description |
+|----------|-------------|
+| `from_nullable(value)` | Convert `T \| None` to `Option[T]` |
+| `sequence_results(results)` | Collect `list[Result]` to `Result[list]` |
+| `traverse_results(items, fn)` | Map and collect Results |
+| `sequence_options(options)` | Collect `list[Option]` to `Option[list]` |
+| `traverse_options(items, fn)` | Map and collect Options |
+| `is_ok(result)` | Type guard for Ok |
+| `is_err(result)` | Type guard for Err |
+| `is_some(option)` | Type guard for Some |
+| `is_nothing(option)` | Type guard for Nothing |
+
+### Serialization
+
+| Function/Class | Description |
+|----------------|-------------|
+| `dumps(obj)` | Serialize to JSON string |
+| `loads(s)` | Deserialize from JSON string |
+| `ResultEncoder` | JSON encoder class |
+| `result_decoder` | JSON decoder hook |

--- a/docs/api/option.md
+++ b/docs/api/option.md
@@ -1,0 +1,144 @@
+# Option API Reference
+
+API documentation for the Option type and related classes.
+
+## Type Alias
+
+```python
+Option[T] = Some[T] | Nothing
+```
+
+A type representing an optional value: either `Some[T]` (present) or `Nothing` (absent).
+
+---
+
+## Some
+
+::: unwrappy.Some
+    options:
+      show_source: false
+      members:
+        - __init__
+        - is_some
+        - is_nothing
+        - map
+        - map_async
+        - map_or
+        - map_or_else
+        - and_then
+        - and_then_async
+        - or_else
+        - or_else_async
+        - filter
+        - filter_async
+        - unwrap
+        - unwrap_or
+        - unwrap_or_else
+        - unwrap_or_raise
+        - expect
+        - tee
+        - inspect
+        - tee_async
+        - inspect_async
+        - inspect_nothing
+        - inspect_nothing_async
+        - ok_or
+        - ok_or_else
+        - flatten
+        - zip
+        - zip_with
+        - xor
+        - to_tuple
+
+---
+
+## Nothing (NOTHING)
+
+The `Nothing` type represents the absence of a value. `NOTHING` is the singleton instance.
+
+```python
+from unwrappy import NOTHING, Option
+
+absent: Option[int] = NOTHING
+```
+
+### Methods
+
+All methods on `Nothing` return appropriate "empty" values:
+
+| Method | Return Value |
+|--------|--------------|
+| `is_some()` | `False` |
+| `is_nothing()` | `True` |
+| `map(fn)` | `NOTHING` |
+| `and_then(fn)` | `NOTHING` |
+| `or_else(fn)` | Result of `fn()` |
+| `filter(pred)` | `NOTHING` |
+| `unwrap()` | Raises `UnwrapError` |
+| `unwrap_or(default)` | `default` |
+| `unwrap_or_else(fn)` | Result of `fn()` |
+| `ok_or(err)` | `Err(err)` |
+| `flatten()` | `NOTHING` |
+| `zip(other)` | `NOTHING` |
+| `xor(other)` | `other` if `other` is Some, else `NOTHING` |
+| `to_tuple()` | `()` |
+
+---
+
+## LazyOption
+
+::: unwrappy.LazyOption
+    options:
+      show_source: false
+      members:
+        - from_option
+        - from_awaitable
+        - some
+        - nothing
+        - map
+        - and_then
+        - or_else
+        - filter
+        - tee
+        - inspect
+        - inspect_nothing
+        - flatten
+        - collect
+
+---
+
+## Type Guards
+
+### is_some
+
+::: unwrappy.is_some
+    options:
+      show_source: false
+
+### is_nothing
+
+::: unwrappy.is_nothing
+    options:
+      show_source: false
+
+---
+
+## Utility Functions
+
+### from_nullable
+
+::: unwrappy.from_nullable
+    options:
+      show_source: false
+
+### sequence_options
+
+::: unwrappy.sequence_options
+    options:
+      show_source: false
+
+### traverse_options
+
+::: unwrappy.traverse_options
+    options:
+      show_source: false

--- a/docs/api/result.md
+++ b/docs/api/result.md
@@ -1,0 +1,161 @@
+# Result API Reference
+
+API documentation for the Result type and related classes.
+
+## Type Alias
+
+```python
+Result[T, E] = Ok[T] | Err[E]
+```
+
+A type representing either success (`Ok[T]`) or failure (`Err[E]`).
+
+---
+
+## Ok
+
+::: unwrappy.Ok
+    options:
+      show_source: false
+      members:
+        - __init__
+        - is_ok
+        - is_err
+        - ok
+        - err
+        - map
+        - map_async
+        - map_err
+        - map_err_async
+        - and_then
+        - and_then_async
+        - or_else
+        - or_else_async
+        - unwrap
+        - unwrap_or
+        - unwrap_or_else
+        - unwrap_or_raise
+        - unwrap_err
+        - expect
+        - tee
+        - inspect
+        - tee_async
+        - inspect_async
+        - inspect_err
+        - inspect_err_async
+        - flatten
+        - split
+        - filter
+        - zip
+        - zip_with
+        - context
+
+---
+
+## Err
+
+::: unwrappy.Err
+    options:
+      show_source: false
+      members:
+        - __init__
+        - is_ok
+        - is_err
+        - ok
+        - err
+        - map
+        - map_async
+        - map_err
+        - map_err_async
+        - and_then
+        - and_then_async
+        - or_else
+        - or_else_async
+        - unwrap
+        - unwrap_or
+        - unwrap_or_else
+        - unwrap_or_raise
+        - unwrap_err
+        - expect
+        - tee
+        - inspect
+        - tee_async
+        - inspect_async
+        - inspect_err
+        - inspect_err_async
+        - flatten
+        - split
+        - filter
+        - zip
+        - zip_with
+        - context
+
+---
+
+## LazyResult
+
+::: unwrappy.LazyResult
+    options:
+      show_source: false
+      members:
+        - from_result
+        - from_awaitable
+        - ok
+        - err
+        - map
+        - map_err
+        - and_then
+        - or_else
+        - tee
+        - inspect
+        - inspect_err
+        - flatten
+        - collect
+
+---
+
+## Type Guards
+
+### is_ok
+
+::: unwrappy.is_ok
+    options:
+      show_source: false
+
+### is_err
+
+::: unwrappy.is_err
+    options:
+      show_source: false
+
+---
+
+## Utility Functions
+
+### sequence_results
+
+::: unwrappy.sequence_results
+    options:
+      show_source: false
+
+### traverse_results
+
+::: unwrappy.traverse_results
+    options:
+      show_source: false
+
+---
+
+## Exceptions
+
+### UnwrapError
+
+::: unwrappy.UnwrapError
+    options:
+      show_source: false
+
+### ChainedError
+
+::: unwrappy.ChainedError
+    options:
+      show_source: false

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,289 @@
+# Architecture
+
+This document explains the design decisions and architectural choices in unwrappy.
+
+## Introduction
+
+### What Problem Does unwrappy Solve?
+
+Python's exception-based error handling has fundamental issues for complex applications:
+
+1. **Hidden control flow**: Exceptions can be raised anywhere and caught anywhere, making it hard to trace error paths
+2. **Unclear contracts**: Function signatures don't declare what exceptions they raise
+3. **Overly broad catching**: `except Exception` can mask bugs like typos causing `NameError`
+4. **Silent failures**: Forgotten exception handling leads to runtime crashes
+
+unwrappy provides `Result[T, E]` and `Option[T]` types that make errors **explicit values** in your code. Instead of throwing exceptions that might be caught (or not), functions return `Ok(value)` or `Err(error)`—making error handling visible and type-checkable.
+
+### Who Is This For?
+
+unwrappy is designed for Python developers who:
+
+- Want **explicit error handling** without hidden control flow
+- Value **type safety** and use type checkers (pyright, mypy, ty)
+- Come from **Rust, Go, or functional programming** backgrounds
+- Build **business logic** where error paths matter as much as happy paths
+- Need **async support** without callback hell
+
+It's particularly useful in:
+
+- API services where errors need to be translated to HTTP responses
+- Data pipelines where partial failures need explicit handling
+- Domain-driven design where business errors are distinct from infrastructure errors
+
+## Addressing Common Concerns
+
+Python developers often express skepticism about Result/Option libraries. Here's how unwrappy addresses the most common criticisms:
+
+### "This adds complexity and takes away Python's simplicity"
+
+**unwrappy's approach**: Minimal API surface, no magic.
+
+Unlike some Result libraries that introduce decorators, operators, and functional programming jargon, unwrappy uses familiar Python patterns:
+
+```python
+# Feels like isinstance() checks
+if result.is_ok():
+    value = result.unwrap()
+
+# Native Python 3.10+ pattern matching
+match result:
+    case Ok(value):
+        print(f"Got: {value}")
+    case Err(error):
+        print(f"Failed: {error}")
+```
+
+No special operators, no monadic bind syntax, no type-level magic. Just classes with methods.
+
+### "This doesn't fit Python's try-except flow"
+
+**unwrappy's approach**: Explicit boundaries with `unwrap_or_raise()`.
+
+unwrappy doesn't try to eliminate exceptions—it provides **explicit boundaries** between Result-based code and exception-based code:
+
+```python
+# Business logic uses Result
+def get_user(user_id: str) -> Result[User, str]:
+    ...
+
+# API boundary converts to exceptions
+@app.get("/users/{user_id}")
+def get_user_endpoint(user_id: str):
+    result = get_user(user_id)
+    return result.unwrap_or_raise(lambda e: HTTPException(404, e))
+```
+
+Use Result in your domain logic where explicit error handling matters. Use exceptions at system boundaries (HTTP handlers, CLI entry points) where frameworks expect them.
+
+### "A mixed codebase is annoying to work with"
+
+**unwrappy's approach**: Designed for mixed codebases.
+
+unwrappy explicitly rejects the "all-or-nothing" philosophy:
+
+- FastAPI routes using `HTTPException` (the framework idiom)
+- Service layer returning `Result` (explicit domain errors)
+- External library calls wrapped explicitly where needed
+
+### "The @safe decorator gets abused"
+
+**unwrappy's approach**: No `@safe` decorator at all.
+
+Many Result libraries provide decorators like `@safe` or `@as_result` that automatically convert exceptions to `Err`. unwrappy intentionally omits these because:
+
+1. **Decorator stacking problems**: Real code already has `@app.route`, `@login_required`, `@cache`, etc.
+2. **Hidden behavior**: A decorator silently catching exceptions makes debugging harder
+3. **Overly broad catching**: `@safe` catches all exceptions, including bugs like `NameError`
+
+Instead, unwrappy requires explicit error handling at the point where it matters.
+
+### "This requires all-or-nothing commitment"
+
+**unwrappy's approach**: Adopt incrementally, use at boundaries you control.
+
+You can use unwrappy in:
+
+- A single module for complex parsing logic
+- Service layer functions while keeping framework idioms elsewhere
+- New code while leaving legacy code unchanged
+
+## Design Philosophy
+
+unwrappy brings Rust's `Result` and `Option` types to Python with these principles:
+
+1. **Errors as values**: Exceptions are implicit control flow; Result makes errors explicit
+2. **Type safety**: Full generic support for static analysis
+3. **Functional composition**: Rich combinator API for transformation chains
+4. **Async ergonomics**: LazyResult solves the "async sandwich" problem
+
+## Type System
+
+```
+Ok[T]    - Success variant (single type parameter)
+Err[E]   - Error variant (single type parameter)
+Result[T, E] = Ok[T] | Err[E]  - Type alias (union)
+LazyResult[T, E] - Deferred execution wrapper
+
+Some[T]  - Present variant (single type parameter)
+Nothing  - Absent variant (singleton type)
+Option[T] = Some[T] | Nothing  - Type alias (union)
+LazyOption[T] - Deferred execution wrapper
+```
+
+## Design Evolution
+
+### Original Design: ABC Pattern
+
+The first implementation used an Abstract Base Class pattern:
+
+```python
+class Result(ABC, Generic[T, E]):
+    @abstractmethod
+    def is_ok(self) -> bool: ...
+    @abstractmethod
+    def map(self, fn: Callable[[T], U]) -> Result[U, E]: ...
+
+class Ok(Result[T, E]):
+    def is_ok(self) -> bool: return True
+
+class Err(Result[T, E]):
+    def is_err(self) -> bool: return True
+```
+
+### The Type Inference Problem
+
+Running `pyright` revealed **295 type errors**. The root cause:
+
+```python
+ok = Ok(42)
+# Inferred type: Ok[int, Unknown]
+#                      ^^^^^^^
+# The E parameter has no source, so it becomes Unknown
+```
+
+With dual type parameters `Ok[T, E]`, creating `Ok(42)` gives the type checker no information about `E`. This cascaded into unusable type inference.
+
+### Solution: Union Type Alias Pattern
+
+Adopting the pattern from [rustedpy/result](https://github.com/rustedpy/result):
+
+```python
+class Ok(Generic[T]): ...     # Only T
+class Err(Generic[E]): ...    # Only E
+Result = Ok[T] | Err[E]       # Type alias, not ABC
+```
+
+With single type parameters:
+
+```python
+ok = Ok(42)
+# Inferred type: Ok[int]  ✓ Precise!
+
+err = Err("failed")
+# Inferred type: Err[str]  ✓ Precise!
+```
+
+**Trade-off accepted:** Methods are duplicated in Ok and Err classes rather than shared via ABC, but the type safety benefits far outweigh the duplication.
+
+## Key Architectural Decisions
+
+### 1. Type Alias Pattern (Union Types)
+
+Result is a type alias for the union of Ok and Err. This gives precise type inference at the cost of some method duplication.
+
+### 2. LazyResult Deferred Execution
+
+LazyResult builds an operation queue without executing anything:
+
+```python
+# This builds a pipeline, executes nothing
+lazy = LazyResult.ok(5).map(double).and_then(validate)
+
+# This executes the entire chain
+result = await lazy.collect()
+```
+
+Operations are stored as frozen dataclasses for immutability and memory efficiency.
+
+### 3. Unified Sync/Async in LazyResult
+
+LazyResult methods accept both sync and async functions via runtime detection:
+
+```python
+lazy.map(sync_fn)           # Works
+lazy.map(async_fn)          # Also works
+```
+
+### 4. Separate Async Methods on Result
+
+Unlike LazyResult, Result has explicit async variants (`map_async`, `and_then_async`) because Result methods execute immediately.
+
+### 5. Nothing as Singleton
+
+Option's `Nothing` is a singleton (like Python's `None`):
+
+```python
+NOTHING = _NothingType()  # Single instance
+assert opt is NOTHING     # Identity comparison works
+```
+
+### 6. No Exception-Catching Decorators
+
+unwrappy intentionally omits `@safe` or `@as_result` decorators. Explicit error handling at each call site is preferred over hidden exception catching.
+
+## Type Checker Limitations
+
+### Known Issues with ty
+
+ty (Astral's type checker) has documented issues with generic TypeVar inference. When using LazyResult factory methods, ty may infer `Unknown` instead of the expected type parameters.
+
+**Workaround**: Use explicit type annotations:
+
+```python
+lazy: LazyResult[int, str] = LazyResult.from_result(Ok(42))
+```
+
+## Comparison with Other Libraries
+
+### vs. rustedpy/result
+
+unwrappy adopted rustedpy's type system pattern. Key differences:
+
+- **`unwrap_or_raise`**: unwrappy takes a factory function for full control over exception creation
+- **No `@as_result`**: Explicit error handling preferred
+- **LazyResult**: Unique feature for async chaining
+
+### vs. dry-python/returns
+
+dry-python/returns is a comprehensive FP library. unwrappy is focused and lightweight:
+
+- Rust naming (`Ok`/`Err` vs `Success`/`Failure`)
+- Built-in `tee()`/`inspect()` for side effects
+- Simpler async with LazyResult vs separate Future containers
+- Zero dependencies
+
+## File Structure
+
+```
+src/unwrappy/
+├── __init__.py      # Public API exports
+├── result.py        # Result, Ok, Err, LazyResult
+├── option.py        # Option, Some, Nothing, LazyOption
+├── serde.py         # JSON serialization support
+└── exceptions.py    # UnwrapError, ChainedError
+```
+
+## Performance Considerations
+
+- **Ok/Err**: Minimal overhead, just value wrapping
+- **LazyResult**: Builds tuple of operations, executes sequentially
+- **Operation dataclasses**: `slots=True` reduces memory footprint
+- **Fail-fast**: Err short-circuits remaining operations
+
+## See Also
+
+- [Getting Started](getting-started.md) - Basic usage
+- [Result Guide](guide/result.md) - Complete Result documentation
+- [Option Guide](guide/option.md) - Complete Option documentation
+- [Lazy Evaluation](guide/lazy-evaluation.md) - Async patterns

--- a/docs/assets/logo-dark.svg
+++ b/docs/assets/logo-dark.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#423e31" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Box body -->
+  <rect x="6" y="6" width="52" height="52" rx="6" />
+
+  <!-- Left eye (upward arc) -->
+  <path d="M 28 28 Q 33 22, 38 28" />
+
+  <!-- Right eye (upward arc) -->
+  <path d="M 42 28 Q 47 22, 52 28" />
+</svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#ebe6d6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Box body -->
+  <rect x="6" y="6" width="52" height="52" rx="6" />
+
+  <!-- Left eye (upward arc) -->
+  <path d="M 28 28 Q 33 22, 38 28" />
+
+  <!-- Right eye (upward arc) -->
+  <path d="M 42 28 Q 47 22, 52 28" />
+</svg>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,304 @@
+# Contributing
+
+Thank you for your interest in contributing to unwrappy! This guide will help you get started with development.
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions. We welcome contributors of all experience levels.
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.10 or higher
+- [uv](https://docs.astral.sh/uv/) package manager
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/leodiegues/unwrappy.git
+cd unwrappy
+
+# Install dependencies
+make install
+```
+
+## Development Commands
+
+| Command | Purpose |
+|---------|---------|
+| `make test` | Run all tests |
+| `make lint` | Lint code with ruff |
+| `make format` | Format code with ruff |
+| `make typecheck` | Type check with pyright, mypy, and ty |
+| `make all` | Run format, lint, typecheck, and tests |
+| `make help` | Show all available commands |
+
+### Running Specific Tests
+
+```bash
+# Single test
+uv run pytest tests/test_result.py::test_ok_map
+
+# Test file
+uv run pytest tests/test_result.py
+
+# With verbose output
+uv run pytest -vv tests/test_result.py
+```
+
+### Building Documentation
+
+```bash
+# Install docs dependencies
+uv sync --group docs
+
+# Serve locally with live reload
+uv run mkdocs serve
+
+# Build static site
+uv run mkdocs build
+```
+
+## Code Style Guidelines
+
+### General
+
+- **Line length**: 120 characters maximum
+- **Quotes**: Double quotes for strings
+- **Docstrings**: Google-style format
+
+### Type Annotations
+
+All public APIs must have complete type annotations:
+
+```python
+def map(self, fn: Callable[[T], U]) -> Ok[U]:
+    """Transform the Ok value using the provided function.
+
+    Args:
+        fn: Function to apply to the contained value.
+
+    Returns:
+        A new Ok containing the transformed value.
+    """
+    return Ok(fn(self._value))
+```
+
+### Docstrings
+
+Use Google-style docstrings:
+
+```python
+def and_then(self, fn: Callable[[T], Result[U, E]]) -> Result[U, E]:
+    """Chain a Result-returning function.
+
+    Also known as "flatMap" or "bind" in functional programming.
+
+    Args:
+        fn: Function that takes the Ok value and returns a new Result.
+
+    Returns:
+        The Result returned by fn if self is Ok, otherwise self unchanged.
+
+    Example:
+        >>> Ok(5).and_then(lambda x: Ok(x * 2))
+        Ok(10)
+        >>> Err("e").and_then(lambda x: Ok(x * 2))
+        Err("e")
+    """
+```
+
+### Imports
+
+Imports are sorted automatically by ruff:
+
+```python
+# Standard library
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
+
+# Local
+from unwrappy.exceptions import UnwrapError
+```
+
+## Testing Requirements
+
+### Coverage
+
+- All new features must include tests
+- Maintain high test coverage (currently 99%)
+- Tests run across Python 3.10-3.14 on Linux, macOS, and Windows
+
+### Test Structure
+
+```python
+# tests/test_result.py
+
+def test_ok_map_transforms_value():
+    """map() should transform Ok values."""
+    result = Ok(5).map(lambda x: x * 2)
+    assert result == Ok(10)
+
+def test_err_map_passes_through():
+    """map() should not transform Err values."""
+    result = Err("error").map(lambda x: x * 2)
+    assert result == Err("error")
+
+@pytest.mark.asyncio
+async def test_ok_map_async():
+    """map_async() should work with async functions."""
+    async def double(x: int) -> int:
+        return x * 2
+
+    result = await Ok(5).map_async(double)
+    assert result == Ok(10)
+```
+
+### Running Full Test Suite
+
+Before submitting a PR:
+
+```bash
+make all
+```
+
+This runs:
+
+1. Code formatting
+2. Linting
+3. Type checking (pyright, mypy, ty)
+4. Tests with coverage
+
+## Pull Request Process
+
+### 1. Fork and Branch
+
+```bash
+# Fork on GitHub, then:
+git clone https://github.com/YOUR_USERNAME/unwrappy.git
+cd unwrappy
+git checkout -b feature/your-feature-name
+```
+
+### 2. Make Changes
+
+- Write code with tests
+- Update documentation if needed
+- Follow code style guidelines
+
+### 3. Run Checks
+
+```bash
+make all
+```
+
+### 4. Commit
+
+Write clear commit messages:
+
+```
+Add filter() method to Result
+
+- Adds filter(predicate, error) method to Ok and Err
+- Returns Err with provided error if predicate fails on Ok value
+- Err values pass through unchanged
+- Includes tests and documentation
+```
+
+### 5. Push and Create PR
+
+```bash
+git push origin feature/your-feature-name
+```
+
+Then create a Pull Request on GitHub against the `main` branch.
+
+### PR Requirements
+
+- [ ] All CI checks pass
+- [ ] Tests added for new features
+- [ ] Documentation updated if needed
+- [ ] No decrease in test coverage
+
+## Project Structure
+
+```
+unwrappy/
+├── src/unwrappy/
+│   ├── __init__.py      # Public API exports
+│   ├── result.py        # Result[T, E] type
+│   ├── option.py        # Option[T] type
+│   ├── exceptions.py    # UnwrapError, ChainedError
+│   └── serde.py         # JSON serialization
+├── tests/
+│   ├── test_result.py
+│   ├── test_option.py
+│   └── test_serde.py
+├── docs/                # Documentation (MkDocs)
+├── examples/            # Usage examples
+├── pyproject.toml       # Project configuration
+└── Makefile            # Development commands
+```
+
+## Adding New Features
+
+### 1. Consider the Design
+
+Before implementing, consider:
+
+- Does this fit unwrappy's design philosophy?
+- Is it commonly needed?
+- Can it be composed from existing methods?
+
+### 2. Implement in Both Variants
+
+Methods on Result/Option need implementations in both variants:
+
+```python
+# In Ok class
+def new_method(self, ...) -> ...:
+    # Ok-specific implementation
+    ...
+
+# In Err class
+def new_method(self, ...) -> ...:
+    # Err-specific implementation (often pass-through)
+    ...
+```
+
+### 3. Add Async Variant if Needed
+
+If the method takes a callable that could be async:
+
+```python
+async def new_method_async(self, fn: Callable[..., Awaitable[...]]) -> ...:
+    ...
+```
+
+### 4. Update Exports
+
+Add to `src/unwrappy/__init__.py`:
+
+```python
+__all__ = [
+    ...,
+    "new_method",  # if it's a standalone function
+]
+```
+
+### 5. Document
+
+- Add docstring with example
+- Update relevant guide page
+- Add to API reference if public
+
+## Questions?
+
+If you have questions or need help:
+
+- Open an issue on [GitHub](https://github.com/leodiegues/unwrappy/issues)
+- Check existing issues and discussions
+
+Thank you for contributing!

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,351 @@
+# Examples
+
+Practical examples demonstrating Result and Option patterns in real-world scenarios.
+
+## Running Examples
+
+The examples are available in the [examples/](https://github.com/leodiegues/unwrappy/tree/main/examples) directory. Run any example from the repository root:
+
+```bash
+uv run --script --with-editable . examples/web_api.py
+```
+
+## Example Files
+
+| File | Description |
+|------|-------------|
+| [web_api.py](https://github.com/leodiegues/unwrappy/blob/main/examples/web_api.py) | FastAPI-style handlers, HTTP error mapping, request validation |
+| [data_processing.py](https://github.com/leodiegues/unwrappy/blob/main/examples/data_processing.py) | CSV/JSON parsing, transformations, batch operations |
+| [database.py](https://github.com/leodiegues/unwrappy/blob/main/examples/database.py) | Option for nullable lookups, repository pattern |
+| [error_handling.py](https://github.com/leodiegues/unwrappy/blob/main/examples/error_handling.py) | Context chaining, recovery patterns, before/after comparison |
+| [async_patterns.py](https://github.com/leodiegues/unwrappy/blob/main/examples/async_patterns.py) | LazyResult/LazyOption, async service composition |
+
+---
+
+## Common Patterns
+
+### Basic Error Handling
+
+Transform a function that raises exceptions into one that returns Result:
+
+```python
+from unwrappy import Ok, Err, Result
+
+def parse_int(s: str) -> Result[int, str]:
+    """Parse a string to int, returning Result instead of raising."""
+    try:
+        return Ok(int(s))
+    except ValueError:
+        return Err(f"'{s}' is not a valid integer")
+
+# Usage
+result = parse_int("42")   # Ok(42)
+result = parse_int("abc")  # Err("'abc' is not a valid integer")
+```
+
+### Chaining Validations
+
+Chain multiple validation steps, short-circuiting on first error:
+
+```python
+from unwrappy import Ok, Err, Result
+
+def validate_username(name: str) -> Result[str, str]:
+    if len(name) < 3:
+        return Err("username must be at least 3 characters")
+    if not name.isalnum():
+        return Err("username must be alphanumeric")
+    return Ok(name)
+
+def validate_email(email: str) -> Result[str, str]:
+    if "@" not in email:
+        return Err("invalid email format")
+    return Ok(email)
+
+def validate_age(age: int) -> Result[int, str]:
+    if age < 18:
+        return Err("must be 18 or older")
+    return Ok(age)
+
+# Chain validations
+def validate_user(name: str, email: str, age: int) -> Result[dict, str]:
+    return (
+        validate_username(name)
+        .and_then(lambda n: validate_email(email).map(lambda e: (n, e)))
+        .and_then(lambda t: validate_age(age).map(lambda a: {
+            "username": t[0],
+            "email": t[1],
+            "age": a
+        }))
+    )
+
+# Usage
+result = validate_user("alice", "alice@example.com", 25)  # Ok({...})
+result = validate_user("ab", "alice@example.com", 25)     # Err("username must be...")
+```
+
+### Error Recovery
+
+Provide fallback values or alternative operations:
+
+```python
+from unwrappy import Ok, Err, Result
+
+def get_config_from_env(key: str) -> Result[str, str]:
+    import os
+    value = os.environ.get(key)
+    if value is None:
+        return Err(f"environment variable {key} not set")
+    return Ok(value)
+
+def get_config_from_file(key: str) -> Result[str, str]:
+    # Try to read from config file
+    config = {"PORT": "8080", "HOST": "localhost"}
+    if key in config:
+        return Ok(config[key])
+    return Err(f"key {key} not in config file")
+
+# Try env first, fall back to file
+port = (
+    get_config_from_env("PORT")
+    .or_else(lambda _: get_config_from_file("PORT"))
+    .unwrap_or("3000")
+)
+```
+
+### Context Chaining
+
+Add context to errors for better debugging:
+
+```python
+from unwrappy import Ok, Err, Result
+
+def read_file(path: str) -> Result[str, str]:
+    try:
+        with open(path) as f:
+            return Ok(f.read())
+    except FileNotFoundError:
+        return Err(f"file not found: {path}")
+
+def parse_json(content: str) -> Result[dict, str]:
+    import json
+    try:
+        return Ok(json.loads(content))
+    except json.JSONDecodeError as e:
+        return Err(f"invalid JSON: {e}")
+
+def load_config(path: str) -> Result[dict, str]:
+    return (
+        read_file(path)
+        .context("reading config file")
+        .and_then(parse_json)
+        .context("parsing config")
+    )
+
+# Error: "parsing config: reading config file: file not found: config.json"
+```
+
+### Web API Pattern
+
+Handle Results at API boundaries:
+
+```python
+from unwrappy import Ok, Err, Result, is_err
+
+# Domain service returns Result
+def get_user(user_id: int) -> Result[dict, str]:
+    users = {1: {"id": 1, "name": "Alice"}}
+    if user_id not in users:
+        return Err(f"user {user_id} not found")
+    return Ok(users[user_id])
+
+def update_user(user_id: int, data: dict) -> Result[dict, str]:
+    user_result = get_user(user_id)
+    if is_err(user_result):
+        return user_result
+
+    user = user_result.unwrap()
+    user.update(data)
+    return Ok(user)
+
+# API handler converts to exceptions
+def api_get_user(user_id: int):
+    """FastAPI-style handler."""
+    match get_user(user_id):
+        case Ok(user):
+            return {"data": user}
+        case Err(error):
+            # raise HTTPException(404, error)
+            return {"error": error, "status": 404}
+
+# Or using unwrap_or_raise
+def api_get_user_v2(user_id: int):
+    user = get_user(user_id).unwrap_or_raise(
+        lambda e: Exception(e)  # Replace with HTTPException
+    )
+    return {"data": user}
+```
+
+### Optional Value Handling
+
+Work with values that may not exist:
+
+```python
+from unwrappy import Some, NOTHING, Option, from_nullable
+
+# Database-style lookup returning Option
+def find_user_by_email(email: str) -> Option[dict]:
+    users = {"alice@example.com": {"id": 1, "name": "Alice"}}
+    return from_nullable(users.get(email))
+
+# Chain operations on optional values
+def get_user_display_name(email: str) -> str:
+    return (
+        find_user_by_email(email)
+        .map(lambda u: u.get("display_name") or u["name"])
+        .map(str.title)
+        .unwrap_or("Unknown User")
+    )
+
+# Convert to Result when error context is needed
+def require_user(email: str) -> Result[dict, str]:
+    return find_user_by_email(email).ok_or(f"no user with email: {email}")
+```
+
+### Batch Processing
+
+Process collections with error handling:
+
+```python
+from unwrappy import Ok, Err, Result, sequence_results, traverse_results
+
+def parse_int(s: str) -> Result[int, str]:
+    try:
+        return Ok(int(s))
+    except ValueError:
+        return Err(f"invalid: {s}")
+
+# Parse multiple values, fail on first error
+inputs = ["1", "2", "3"]
+result = traverse_results(inputs, parse_int)  # Ok([1, 2, 3])
+
+inputs = ["1", "x", "3"]
+result = traverse_results(inputs, parse_int)  # Err("invalid: x")
+
+# Combine existing Results
+results = [Ok(1), Ok(2), Ok(3)]
+combined = sequence_results(results)  # Ok([1, 2, 3])
+```
+
+### Async Service Composition
+
+Build async pipelines with LazyResult:
+
+```python
+from unwrappy import LazyResult, Ok, Err, Result
+
+# Simulated async services
+async def fetch_user(user_id: int) -> Result[dict, str]:
+    if user_id <= 0:
+        return Err("invalid user id")
+    return Ok({"id": user_id, "name": "Alice"})
+
+async def fetch_orders(user: dict) -> Result[list, str]:
+    return Ok([{"id": 1, "total": 100}, {"id": 2, "total": 200}])
+
+async def calculate_total(orders: list) -> int:
+    return sum(o["total"] for o in orders)
+
+# Build and execute pipeline
+async def get_user_total(user_id: int) -> Result[int, str]:
+    return await (
+        LazyResult.from_awaitable(fetch_user(user_id))
+        .and_then(fetch_orders)
+        .map(calculate_total)  # Works with both sync and async!
+        .tee(lambda total: print(f"Total: ${total}"))
+        .collect()
+    )
+
+# Usage
+# result = await get_user_total(42)  # Ok(300)
+```
+
+### Type Guard for Early Returns
+
+Use type guards for proper type narrowing:
+
+```python
+from unwrappy import Ok, Err, Result, is_err, is_ok
+
+def process_data(raw: str) -> Result[dict, str]:
+    # Parse step
+    parsed = parse_json(raw)
+    if is_err(parsed):
+        return parsed  # Type checker knows this is Err
+
+    # Validate step
+    validated = validate_schema(parsed.unwrap())
+    if is_err(validated):
+        return validated
+
+    # Transform step
+    data = validated.unwrap()
+    return Ok({"processed": data, "timestamp": time.time()})
+```
+
+### Combining Option with Result
+
+Convert between Option and Result as needed:
+
+```python
+from unwrappy import Some, NOTHING, Option, Ok, Err, Result, from_nullable
+
+def find_config(key: str) -> Option[str]:
+    """Returns Option - value may not exist."""
+    config = {"api_key": "secret123"}
+    return from_nullable(config.get(key))
+
+def require_config(key: str) -> Result[str, str]:
+    """Returns Result - missing config is an error."""
+    return find_config(key).ok_or(f"missing required config: {key}")
+
+def get_optional_config(key: str, default: str) -> str:
+    """Returns value or default."""
+    return find_config(key).unwrap_or(default)
+
+# Usage
+api_key = require_config("api_key")         # Ok("secret123")
+missing = require_config("missing")         # Err("missing required config: missing")
+timeout = get_optional_config("timeout", "30")  # "30"
+```
+
+### Logging and Side Effects
+
+Use tee/inspect for debugging without breaking chains:
+
+```python
+import logging
+from unwrappy import Ok, Err, Result
+
+logger = logging.getLogger(__name__)
+
+def fetch_and_process(url: str) -> Result[dict, str]:
+    return (
+        fetch_data(url)
+        .tee(lambda d: logger.info(f"Fetched {len(d)} bytes from {url}"))
+        .and_then(parse_json)
+        .tee(lambda j: logger.debug(f"Parsed JSON: {j}"))
+        .inspect_err(lambda e: logger.error(f"Processing failed: {e}"))
+        .and_then(validate)
+        .tee(lambda v: logger.info(f"Validation passed"))
+    )
+```
+
+---
+
+## See Also
+
+- [Getting Started](getting-started.md) - Basic usage and concepts
+- [Result Guide](guide/result.md) - Complete Result documentation
+- [Option Guide](guide/option.md) - Complete Option documentation
+- [Lazy Evaluation](guide/lazy-evaluation.md) - Async patterns

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,221 @@
+# Getting Started
+
+This guide will help you get up and running with unwrappy in minutes.
+
+## Installation
+
+=== "pip"
+
+    ```bash
+    pip install unwrappy
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add unwrappy
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add unwrappy
+    ```
+
+## Requirements
+
+- Python 3.10 or higher
+- No external dependencies
+
+## Basic Usage
+
+### Your First Result
+
+The `Result` type represents an operation that can succeed or fail:
+
+```python
+from unwrappy import Ok, Err, Result
+
+def divide(a: float, b: float) -> Result[float, str]:
+    """Divide two numbers, returning an error for division by zero."""
+    if b == 0:
+        return Err("cannot divide by zero")
+    return Ok(a / b)
+```
+
+### Handling Results
+
+There are several ways to handle a `Result`:
+
+#### Pattern Matching (Recommended)
+
+Python 3.10+ structural pattern matching is the most explicit way:
+
+```python
+match divide(10, 2):
+    case Ok(value):
+        print(f"Result: {value}")  # Result: 5.0
+    case Err(error):
+        print(f"Error: {error}")
+```
+
+#### Checking and Unwrapping
+
+For simpler cases, check the variant and extract the value:
+
+```python
+result = divide(10, 2)
+
+if result.is_ok():
+    print(result.unwrap())  # 5.0
+else:
+    print(result.unwrap_err())  # Would print the error message
+```
+
+#### Safe Extraction with Defaults
+
+When you want a fallback value:
+
+```python
+# With a default value
+value = divide(10, 0).unwrap_or(0.0)  # 0.0
+
+# With a computed default
+value = divide(10, 0).unwrap_or_else(lambda e: float("inf"))  # inf
+```
+
+### Chaining Operations
+
+The real power comes from chaining operations:
+
+```python
+def parse_int(s: str) -> Result[int, str]:
+    try:
+        return Ok(int(s))
+    except ValueError:
+        return Err(f"'{s}' is not a valid integer")
+
+def validate_positive(n: int) -> Result[int, str]:
+    if n <= 0:
+        return Err("number must be positive")
+    return Ok(n)
+
+# Chain multiple operations
+result = (
+    parse_int("42")
+    .and_then(validate_positive)
+    .map(lambda x: x * 2)
+)
+
+print(result)  # Ok(84)
+```
+
+If any step fails, the chain short-circuits:
+
+```python
+result = (
+    parse_int("not a number")  # This fails
+    .and_then(validate_positive)  # Skipped
+    .map(lambda x: x * 2)  # Skipped
+)
+
+print(result)  # Err("'not a number' is not a valid integer")
+```
+
+## Working with Optional Values
+
+The `Option` type handles values that may or may not exist:
+
+```python
+from unwrappy import Some, NOTHING, Option, from_nullable
+
+# Create Options manually
+present: Option[int] = Some(42)
+absent: Option[int] = NOTHING
+
+# Convert from nullable Python values
+def get_config_value(key: str) -> str | None:
+    return {"debug": "true"}.get(key)
+
+opt = from_nullable(get_config_value("debug"))  # Some("true")
+opt = from_nullable(get_config_value("missing"))  # NOTHING
+```
+
+### Option Chaining
+
+Chain operations on optional values:
+
+```python
+# Get a config value, parse it, and provide a default
+debug_enabled = (
+    from_nullable(get_config_value("debug"))
+    .map(lambda s: s.lower() == "true")
+    .unwrap_or(False)
+)
+```
+
+## Type Safety
+
+unwrappy is designed for type checkers. Your IDE will catch errors:
+
+```python
+from unwrappy import Ok, Err, Result
+
+def get_user(id: int) -> Result[User, str]:
+    ...
+
+result = get_user(42)
+
+# Type checker knows result could be Ok or Err
+user = result.unwrap()  # Type checker warns: could raise UnwrapError!
+
+# Safe pattern matching - type checker knows value is User
+match result:
+    case Ok(user):
+        print(user.name)  # user is typed as User
+    case Err(error):
+        print(error)  # error is typed as str
+```
+
+## Integration with Existing Code
+
+unwrappy is designed for gradual adoption. Use it alongside exceptions:
+
+```python
+from unwrappy import Ok, Err, Result
+
+# Business logic uses Result
+def validate_email(email: str) -> Result[str, str]:
+    if "@" not in email:
+        return Err("invalid email format")
+    return Ok(email)
+
+# API boundary converts to exceptions
+@app.post("/users")
+def create_user(email: str):
+    match validate_email(email):
+        case Ok(valid_email):
+            return {"email": valid_email}
+        case Err(error):
+            raise HTTPException(400, error)
+```
+
+Or use `unwrap_or_raise` for cleaner conversion:
+
+```python
+@app.post("/users")
+def create_user(email: str):
+    valid_email = validate_email(email).unwrap_or_raise(
+        lambda e: HTTPException(400, e)
+    )
+    return {"email": valid_email}
+```
+
+## Next Steps
+
+Now that you understand the basics:
+
+- [**Result Guide**](guide/result.md) - Deep dive into Result methods and patterns
+- [**Option Guide**](guide/option.md) - Working with optional values
+- [**Lazy Evaluation**](guide/lazy-evaluation.md) - Async patterns with LazyResult
+- [**Examples**](examples.md) - Real-world code examples

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,0 +1,96 @@
+# Guide
+
+This guide provides comprehensive documentation for unwrappy's core types and patterns.
+
+## Core Concepts
+
+unwrappy brings Rust's approach to error handling to Python:
+
+- **Errors as values** - Instead of throwing exceptions, functions return `Result` types that explicitly represent success or failure
+- **Optional values** - Instead of `None`, use `Option` to make optionality explicit and chainable
+- **Functional composition** - Chain operations with combinators like `map`, `and_then`, and `or_else`
+
+## Type System
+
+```
+Result[T, E] = Ok[T] | Err[E]
+  - Ok[T]   : Success variant containing a value of type T
+  - Err[E]  : Error variant containing an error of type E
+
+Option[T] = Some[T] | Nothing
+  - Some[T] : Present variant containing a value of type T
+  - Nothing : Absent variant (singleton)
+
+LazyResult[T, E] : Deferred Result computation for async chains
+LazyOption[T]    : Deferred Option computation for async chains
+```
+
+## Guide Sections
+
+<div class="grid cards" markdown>
+
+-   :material-check-circle:{ .lg .middle } **Result Type**
+
+    ---
+
+    The `Result[T, E]` type for operations that can fail. Learn about `Ok`, `Err`, and all the transformation methods.
+
+    [:octicons-arrow-right-24: Result Guide](result.md)
+
+-   :material-help-circle:{ .lg .middle } **Option Type**
+
+    ---
+
+    The `Option[T]` type for values that may not exist. Learn about `Some`, `Nothing`, and optional value handling.
+
+    [:octicons-arrow-right-24: Option Guide](option.md)
+
+-   :material-lightning-bolt:{ .lg .middle } **Lazy Evaluation**
+
+    ---
+
+    `LazyResult` and `LazyOption` for building async operation pipelines without nested awaits.
+
+    [:octicons-arrow-right-24: Lazy Evaluation](lazy-evaluation.md)
+
+-   :material-code-json:{ .lg .middle } **Serialization**
+
+    ---
+
+    JSON serialization support for task queues and distributed systems (Celery, Temporal, DBOS).
+
+    [:octicons-arrow-right-24: Serialization](serialization.md)
+
+</div>
+
+## Quick Reference
+
+### Result Methods
+
+| Category | Methods |
+|----------|---------|
+| **Checking** | `is_ok()`, `is_err()` |
+| **Transformation** | `map()`, `map_err()`, `and_then()`, `or_else()` |
+| **Extraction** | `unwrap()`, `unwrap_or()`, `unwrap_or_else()`, `expect()` |
+| **Inspection** | `tee()`, `inspect()`, `inspect_err()` |
+| **Conversion** | `ok()`, `err()`, `flatten()`, `split()` |
+
+### Option Methods
+
+| Category | Methods |
+|----------|---------|
+| **Checking** | `is_some()`, `is_nothing()` |
+| **Transformation** | `map()`, `and_then()`, `or_else()`, `filter()` |
+| **Extraction** | `unwrap()`, `unwrap_or()`, `unwrap_or_else()`, `expect()` |
+| **Inspection** | `tee()`, `inspect()`, `inspect_nothing()` |
+| **Conversion** | `ok_or()`, `ok_or_else()`, `flatten()`, `to_tuple()` |
+
+### Utility Functions
+
+| Function | Description |
+|----------|-------------|
+| `from_nullable(value)` | Convert `T | None` to `Option[T]` |
+| `sequence_results(results)` | Collect `list[Result]` into `Result[list]` |
+| `traverse_results(items, fn)` | Map and collect Results |
+| `sequence_options(options)` | Collect `list[Option]` into `Option[list]` |
+| `traverse_options(items, fn)` | Map and collect Options |

--- a/docs/guide/lazy-evaluation.md
+++ b/docs/guide/lazy-evaluation.md
@@ -1,0 +1,324 @@
+# Lazy Evaluation
+
+`LazyResult` and `LazyOption` provide deferred execution for building async operation pipelines without nested awaits.
+
+## The Problem with Async Chains
+
+Traditional async code requires nested awaits:
+
+```python
+async def fetch_user(id: int) -> Result[User, str]: ...
+async def fetch_posts(user: User) -> Result[list[Post], str]: ...
+async def fetch_comments(post: Post) -> Result[list[Comment], str]: ...
+
+# Without LazyResult - nested awaits everywhere
+user_result = await fetch_user(42)
+if user_result.is_err():
+    return user_result
+
+posts_result = await fetch_posts(user_result.unwrap())
+if posts_result.is_err():
+    return posts_result
+
+# ... and so on
+```
+
+Or with `and_then_async`, you still need multiple awaits:
+
+```python
+result = await (await fetch_user(42)).and_then_async(fetch_posts)
+```
+
+## LazyResult Solution
+
+LazyResult builds an operation queue without executing anything, then runs the entire chain with a single `await`:
+
+```python
+from unwrappy import LazyResult
+
+result = await (
+    LazyResult.from_awaitable(fetch_user(42))
+    .and_then(fetch_posts)
+    .map(lambda posts: len(posts))
+    .tee(lambda n: print(f"Found {n} posts"))
+    .collect()
+)
+```
+
+The key insight: **build the pipeline, execute once**.
+
+## Creating LazyResults
+
+### From an Awaitable
+
+```python
+async def fetch_data() -> Result[Data, str]: ...
+
+lazy = LazyResult.from_awaitable(fetch_data())
+```
+
+### From an Existing Result
+
+```python
+lazy = LazyResult.from_result(Ok(42))
+lazy = LazyResult.from_result(Err("oops"))
+```
+
+### Factory Methods
+
+```python
+lazy = LazyResult.ok(42)       # Wraps Ok(42)
+lazy = LazyResult.err("oops")  # Wraps Err("oops")
+```
+
+## Transformation Methods
+
+LazyResult supports all the same methods as Result, but deferred:
+
+### Transform Ok Value
+
+```python
+lazy = (
+    LazyResult.ok(5)
+    .map(lambda x: x * 2)      # Sync function
+    .map(async_transform)      # Async function - also works!
+)
+```
+
+### Transform Err Value
+
+```python
+lazy = (
+    LazyResult.err("error")
+    .map_err(lambda e: f"wrapped: {e}")
+)
+```
+
+### Chain Result-Returning Functions
+
+```python
+async def validate(data: Data) -> Result[ValidData, str]: ...
+async def process(data: ValidData) -> Result[Output, str]: ...
+
+lazy = (
+    LazyResult.from_awaitable(fetch_data())
+    .and_then(validate)   # Async function
+    .and_then(process)    # Async function
+)
+```
+
+### Recover from Errors
+
+```python
+async def try_backup(e: str) -> Result[Data, str]: ...
+
+lazy = (
+    LazyResult.from_awaitable(primary_fetch())
+    .or_else(try_backup)  # Called only if primary fails
+)
+```
+
+### Side Effects
+
+```python
+lazy = (
+    LazyResult.ok(42)
+    .tee(lambda x: print(f"Value: {x}"))          # Sync
+    .tee(async_log)                                # Async
+    .inspect_err(lambda e: logger.error(e))
+)
+```
+
+### Unwrap Nested Results
+
+```python
+# If your function returns Result[Result[T, E], E]
+lazy = LazyResult.ok(Ok(42)).flatten()  # Produces Ok(42)
+```
+
+## Executing the Pipeline
+
+### Execute and Get Result
+
+```python
+result = await lazy.collect()  # Returns Result[T, E]
+
+match result:
+    case Ok(value):
+        print(f"Success: {value}")
+    case Err(error):
+        print(f"Error: {error}")
+```
+
+!!! important
+    `collect()` is the only way to execute a LazyResult pipeline. All operations before `collect()` are deferred.
+
+## Mixing Sync and Async
+
+LazyResult transparently handles both sync and async functions:
+
+```python
+def double(x: int) -> int:
+    return x * 2
+
+async def fetch_multiplier() -> int:
+    return await some_async_call()
+
+async def multiply(x: int) -> Result[int, str]:
+    m = await fetch_multiplier()
+    return Ok(x * m)
+
+result = await (
+    LazyResult.ok(5)
+    .map(double)           # Sync - no await needed
+    .and_then(multiply)    # Async - handled automatically
+    .map(double)           # Sync again
+    .collect()
+)
+```
+
+## LazyOption
+
+`LazyOption` works the same way for Option types:
+
+```python
+from unwrappy import LazyOption, Some, NOTHING
+
+async def fetch_config(key: str) -> Option[str]: ...
+async def parse_value(s: str) -> Option[int]: ...
+
+result = await (
+    LazyOption.from_awaitable(fetch_config("timeout"))
+    .and_then(parse_value)
+    .map(lambda x: x * 1000)  # Convert to milliseconds
+    .collect()
+)
+```
+
+### Creating LazyOptions
+
+```python
+lazy = LazyOption.from_awaitable(async_option_func())
+lazy = LazyOption.from_option(Some(42))
+lazy = LazyOption.some(42)
+lazy = LazyOption.nothing()
+```
+
+### LazyOption Methods
+
+All Option methods are available:
+
+- `map(fn)` - Transform Some value
+- `and_then(fn)` - Chain Option-returning function
+- `or_else(fn)` - Provide alternative
+- `filter(predicate)` - Keep if predicate passes
+- `tee(fn)` / `inspect(fn)` - Side effect on Some
+- `inspect_nothing(fn)` - Side effect on Nothing
+- `flatten()` - Unwrap nested Options
+- `collect()` - Execute and get Option
+
+## Real-World Example
+
+A complete async service composition:
+
+```python
+from unwrappy import LazyResult, Ok, Err, Result
+from dataclasses import dataclass
+
+@dataclass
+class User:
+    id: int
+    name: str
+
+@dataclass
+class Profile:
+    user: User
+    posts_count: int
+    followers_count: int
+
+async def fetch_user(user_id: int) -> Result[User, str]:
+    # Simulate DB call
+    if user_id <= 0:
+        return Err("invalid user id")
+    return Ok(User(user_id, "Alice"))
+
+async def fetch_posts_count(user: User) -> Result[int, str]:
+    # Simulate API call
+    return Ok(42)
+
+async def fetch_followers_count(user: User) -> Result[int, str]:
+    # Simulate API call
+    return Ok(100)
+
+async def build_profile(user_id: int) -> Result[Profile, str]:
+    # First, get the user
+    user_result = await LazyResult.from_awaitable(
+        fetch_user(user_id)
+    ).collect()
+
+    if user_result.is_err():
+        return user_result  # type: ignore
+
+    user = user_result.unwrap()
+
+    # Then fetch counts in parallel (using regular async)
+    import asyncio
+    posts_result, followers_result = await asyncio.gather(
+        LazyResult.from_awaitable(fetch_posts_count(user)).collect(),
+        LazyResult.from_awaitable(fetch_followers_count(user)).collect(),
+    )
+
+    # Combine results
+    return (
+        posts_result
+        .and_then(lambda posts:
+            followers_result.map(lambda followers:
+                Profile(user, posts, followers)
+            )
+        )
+    )
+
+# Usage
+profile = await build_profile(42)
+match profile:
+    case Ok(p):
+        print(f"{p.user.name}: {p.posts_count} posts, {p.followers_count} followers")
+    case Err(e):
+        print(f"Error: {e}")
+```
+
+## Serialization Limitation
+
+!!! warning "LazyResult cannot be serialized"
+    `LazyResult` and `LazyOption` contain function references (lambdas, async functions) which cannot be serialized to JSON.
+
+    Always call `.collect()` before serializing:
+
+    ```python
+    from unwrappy import dumps
+
+    # This will raise TypeError
+    lazy = LazyResult.ok(42).map(lambda x: x * 2)
+    dumps(lazy)  # TypeError!
+
+    # Do this instead
+    result = await lazy.collect()
+    dumps(result)  # Ok!
+    ```
+
+## Performance Considerations
+
+- **Operation queue**: LazyResult builds a tuple of operations, then executes them sequentially
+- **Short-circuiting**: Err values skip remaining operations
+- **Memory**: Operation dataclasses use `slots=True` for minimal footprint
+- **No caching**: Each `collect()` re-executes the pipeline
+
+## Type Inference Notes
+
+Due to Python's type system limitations, some type checkers may have trouble inferring types through long LazyResult chains. If needed, add explicit type annotations:
+
+```python
+lazy: LazyResult[int, str] = LazyResult.ok(42)
+```
+
+See the [Architecture docs](../architecture.md#type-checker-limitations) for more details.

--- a/docs/guide/option.md
+++ b/docs/guide/option.md
@@ -1,0 +1,471 @@
+# Option Type
+
+The `Option[T]` type represents a value that may or may not be present: either `Some(value)` or `Nothing`.
+
+## Overview
+
+```python
+from unwrappy import Some, NOTHING, Option
+
+# Value is present
+some: Option[int] = Some(42)
+
+# Value is absent
+nothing: Option[int] = NOTHING
+```
+
+Option is a **union type** (type alias):
+
+```python
+Option[T] = Some[T] | Nothing
+```
+
+Where `Nothing` is a singleton (like Python's `None`).
+
+## Creating Options
+
+### Present Variant
+
+```python
+from unwrappy import Some
+
+opt = Some(42)              # Some[int]
+opt = Some("hello")         # Some[str]
+opt = Some([1, 2, 3])       # Some[list[int]]
+```
+
+### Absent Variant
+
+```python
+from unwrappy import NOTHING, Option
+
+# NOTHING is a singleton
+opt: Option[int] = NOTHING
+
+# All NOTHING values are the same instance
+assert NOTHING is NOTHING  # True
+```
+
+!!! note "NOTHING vs Nothing"
+    - `NOTHING` is the singleton value (use in code)
+    - `Nothing` is the type alias (use in type hints): `def foo() -> Option[int]:` can return `NOTHING`
+
+### Convert from Python's None
+
+The most common way to create Options from existing code:
+
+```python
+from unwrappy import from_nullable
+
+# Convert nullable values
+opt = from_nullable(None)        # NOTHING
+opt = from_nullable(42)          # Some(42)
+opt = from_nullable("")          # Some("") - empty string is not None!
+opt = from_nullable([])          # Some([]) - empty list is not None!
+
+# Common pattern with dict.get()
+config = {"debug": "true"}
+opt = from_nullable(config.get("debug"))    # Some("true")
+opt = from_nullable(config.get("missing"))  # NOTHING
+```
+
+## Option vs typing.Optional
+
+Python's `Optional[T]` is just `T | None` - it doesn't distinguish between "value is absent" and "value is explicitly None".
+
+Option makes this explicit:
+
+```python
+# typing.Optional - ambiguous
+def get_setting() -> str | None:
+    return None  # Is this "no setting" or "setting is null"?
+
+# unwrappy.Option - clear
+def get_setting() -> Option[str]:
+    return Some("value")  # Setting exists
+    return NOTHING        # No setting
+```
+
+### Three-State Logic with Option[T | None]
+
+For PATCH-style updates where you need to distinguish between "don't update", "set to null", and "set to value":
+
+```python
+from dataclasses import dataclass, field
+from unwrappy import Option, Some, NOTHING
+
+@dataclass
+class UserUpdate:
+    # NOTHING = don't update this field
+    # Some(None) = set field to null
+    # Some(value) = set field to value
+    name: Option[str | None] = NOTHING
+    email: Option[str | None] = NOTHING
+
+def apply_update(user: User, update: UserUpdate) -> User:
+    match update.name:
+        case Some(None):
+            user.name = None  # Explicitly set to null
+        case Some(name):
+            user.name = name  # Set to new value
+        case _:
+            pass  # NOTHING - don't change
+
+    return user
+```
+
+## Checking Variants
+
+### Methods
+
+```python
+some = Some(42)
+nothing = NOTHING
+
+some.is_some()      # True
+some.is_nothing()   # False
+
+nothing.is_some()   # False
+nothing.is_nothing() # True
+```
+
+### Type Guard Functions
+
+For proper type narrowing:
+
+```python
+from unwrappy import Option, Some, NOTHING, is_some, is_nothing
+
+def process(opt: Option[int]) -> int:
+    if is_nothing(opt):
+        return 0
+
+    # Type checker knows opt is Some[int] here
+    return opt.unwrap() * 2
+```
+
+## Pattern Matching
+
+The recommended way to handle Options (Python 3.10+):
+
+```python
+from unwrappy import Some, NOTHING, Option
+
+def describe(opt: Option[int]) -> str:
+    match opt:
+        case Some(value):
+            return f"Got: {value}"
+        case _:  # NOTHING
+            return "Nothing here"
+```
+
+!!! tip "Matching NOTHING"
+    Use `case _:` or `case NOTHING` (imported) to match the Nothing variant. Using `case Nothing:` without import won't work as expected.
+
+## Extracting Values
+
+### Get Value or Raise
+
+```python
+Some(42).unwrap()   # 42
+NOTHING.unwrap()    # Raises UnwrapError
+```
+
+### With Default
+
+```python
+Some(42).unwrap_or(0)   # 42
+NOTHING.unwrap_or(0)    # 0
+```
+
+### With Computed Default
+
+```python
+Some(42).unwrap_or_else(lambda: expensive_default())   # 42 (lambda not called)
+NOTHING.unwrap_or_else(lambda: expensive_default())    # calls expensive_default()
+```
+
+### Convert to Exception
+
+```python
+Some(42).unwrap_or_raise(ValueError("missing"))   # 42
+NOTHING.unwrap_or_raise(ValueError("missing"))    # Raises ValueError
+```
+
+### With Custom Message
+
+```python
+Some(42).expect("value required")   # 42
+NOTHING.expect("value required")    # Raises UnwrapError("value required")
+```
+
+## Transformation Methods
+
+### Transform Some Value
+
+```python
+Some(5).map(lambda x: x * 2)   # Some(10)
+NOTHING.map(lambda x: x * 2)   # NOTHING
+```
+
+### Transform or Return Default
+
+```python
+Some(5).map_or(0, lambda x: x * 2)   # 10
+NOTHING.map_or(0, lambda x: x * 2)   # 0
+```
+
+### Transform or Compute Default
+
+```python
+Some(5).map_or_else(lambda: 0, lambda x: x * 2)   # 10
+NOTHING.map_or_else(lambda: 0, lambda x: x * 2)   # 0
+```
+
+### Chain Option-Returning Functions
+
+```python
+def parse_port(s: str) -> Option[int]:
+    try:
+        port = int(s)
+        return Some(port) if 1 <= port <= 65535 else NOTHING
+    except ValueError:
+        return NOTHING
+
+Some("8080").and_then(parse_port)    # Some(8080)
+Some("invalid").and_then(parse_port) # NOTHING
+NOTHING.and_then(parse_port)         # NOTHING
+```
+
+### Provide Alternative
+
+```python
+def get_from_env() -> Option[str]:
+    return from_nullable(os.environ.get("CONFIG"))
+
+def get_from_file() -> Option[str]:
+    return Some("default") if path.exists() else NOTHING
+
+config = get_from_env().or_else(get_from_file)
+```
+
+### Keep Value If Predicate Passes
+
+```python
+Some(42).filter(lambda x: x > 0)    # Some(42)
+Some(-5).filter(lambda x: x > 0)    # NOTHING
+NOTHING.filter(lambda x: x > 0)     # NOTHING
+```
+
+## Inspection Methods
+
+### Side Effect on Some
+
+```python
+result = (
+    Some(42)
+    .tee(lambda x: print(f"Got: {x}"))  # Prints "Got: 42"
+    .map(lambda x: x * 2)
+)
+# result is Some(84)
+```
+
+### Side Effect on Nothing
+
+```python
+result = (
+    NOTHING
+    .inspect_nothing(lambda: logger.warning("No value found"))
+    .or_else(get_default)
+)
+```
+
+## Combining Options
+
+### Combine Two Options
+
+```python
+Some(1).zip(Some(2))    # Some((1, 2))
+Some(1).zip(NOTHING)    # NOTHING
+NOTHING.zip(Some(2))    # NOTHING
+```
+
+### Combine with Function
+
+```python
+Some(10).zip_with(Some(3), lambda a, b: a + b)  # Some(13)
+```
+
+### Unwrap Nested Options
+
+```python
+Some(Some(42)).flatten()  # Some(42)
+Some(NOTHING).flatten()   # NOTHING
+NOTHING.flatten()         # NOTHING
+```
+
+### Exactly One Must Be Some
+
+```python
+Some(1).xor(NOTHING)   # Some(1)
+NOTHING.xor(Some(2))   # Some(2)
+Some(1).xor(Some(2))   # NOTHING (both are Some)
+NOTHING.xor(NOTHING)   # NOTHING (neither is Some)
+```
+
+## Conversion Methods
+
+### Convert to Result
+
+```python
+from unwrappy import Some, NOTHING
+
+Some(42).ok_or("missing")   # Ok(42)
+NOTHING.ok_or("missing")    # Err("missing")
+```
+
+### Convert to Result with Computed Error
+
+```python
+Some(42).ok_or_else(lambda: "missing")   # Ok(42)
+NOTHING.ok_or_else(lambda: "missing")    # Err("missing")
+```
+
+### Convert to Single-Element Tuple or Empty
+
+```python
+Some(42).to_tuple()  # (42,)
+NOTHING.to_tuple()   # ()
+```
+
+Useful for unpacking:
+
+```python
+for value in Some(42).to_tuple():
+    print(value)  # Prints 42
+
+for value in NOTHING.to_tuple():
+    print(value)  # Nothing printed
+```
+
+## Async Methods
+
+All transformation methods have async variants:
+
+```python
+async def fetch_details(id: int) -> str:
+    ...
+
+opt = await Some(42).map_async(fetch_details)  # Some("details...")
+```
+
+Available async methods:
+
+- `map_async(fn)` - Transform with async function
+- `and_then_async(fn)` - Chain async Option-returning function
+- `or_else_async(fn)` - Provide async alternative
+- `tee_async(fn)` / `inspect_async(fn)` - Async side effect on Some
+- `inspect_nothing_async(fn)` - Async side effect on Nothing
+
+## Batch Operations
+
+### Collect Options
+
+Convert a list of Options into an Option of a list:
+
+```python
+from unwrappy import Some, NOTHING, sequence_options
+
+options = [Some(1), Some(2), Some(3)]
+combined = sequence_options(options)  # Some([1, 2, 3])
+
+options = [Some(1), NOTHING, Some(3)]
+combined = sequence_options(options)  # NOTHING - fails fast
+```
+
+### Map and Collect
+
+Map a function over items and collect Options:
+
+```python
+from unwrappy import traverse_options, from_nullable
+
+items = [1, 2, 3]
+result = traverse_options(items, lambda x: Some(x * 2))  # Some([2, 4, 6])
+
+# With nullable values
+items: list[int | None] = [1, 2, 3]
+result = traverse_options(items, from_nullable)  # Some([1, 2, 3])
+
+items: list[int | None] = [1, None, 3]
+result = traverse_options(items, from_nullable)  # NOTHING
+```
+
+## Best Practices
+
+### 1. Use `from_nullable()` at Boundaries
+
+Convert nullable values to Option at the boundary of your domain logic:
+
+```python
+def get_user_email(user_id: int) -> Option[str]:
+    # External API returns str | None
+    email = external_api.get_email(user_id)
+    return from_nullable(email)
+```
+
+### 2. Chain Operations
+
+Prefer chaining over nested conditionals:
+
+```python
+# Instead of this:
+email = get_email()
+if email is not None:
+    domain = email.split("@")[1] if "@" in email else None
+    if domain is not None:
+        result = domain.lower()
+    else:
+        result = "unknown"
+else:
+    result = "unknown"
+
+# Do this:
+result = (
+    from_nullable(get_email())
+    .filter(lambda e: "@" in e)
+    .map(lambda e: e.split("@")[1])
+    .map(str.lower)
+    .unwrap_or("unknown")
+)
+```
+
+### 3. Convert to Result When Error Context Matters
+
+When you need to know *why* a value is missing:
+
+```python
+def get_config(key: str) -> Option[str]:
+    return from_nullable(config.get(key))
+
+def get_required_config(key: str) -> Result[str, str]:
+    return get_config(key).ok_or(f"Missing required config: {key}")
+
+# Now you have error context
+match get_required_config("API_KEY"):
+    case Ok(key):
+        use_key(key)
+    case Err(error):
+        print(error)  # "Missing required config: API_KEY"
+```
+
+### 4. Use `filter()` for Validation
+
+```python
+def parse_port(s: str) -> Option[int]:
+    return (
+        from_nullable(s)
+        .and_then(lambda s: Some(int(s)) if s.isdigit() else NOTHING)
+        .filter(lambda p: 1 <= p <= 65535)
+    )
+```

--- a/docs/guide/result.md
+++ b/docs/guide/result.md
@@ -1,0 +1,439 @@
+# Result Type
+
+The `Result[T, E]` type represents an operation that can either succeed with a value of type `T` or fail with an error of type `E`.
+
+## Overview
+
+```python
+from unwrappy import Ok, Err, Result
+
+# Success case
+ok: Result[int, str] = Ok(42)
+
+# Error case
+err: Result[int, str] = Err("something went wrong")
+```
+
+Result is a **union type** (type alias):
+
+```python
+Result[T, E] = Ok[T] | Err[E]
+```
+
+This means `Ok` and `Err` are separate classes, each with a single type parameter for precise type inference.
+
+## Creating Results
+
+### Success Variant (`Ok`)
+
+```python
+from unwrappy import Ok
+
+# Simple value
+result = Ok(42)  # Ok[int]
+
+# Complex types
+result = Ok({"name": "Alice", "age": 30})  # Ok[dict[str, Any]]
+result = Ok([1, 2, 3])  # Ok[list[int]]
+```
+
+### Error Variant (`Err`)
+
+```python
+from unwrappy import Err
+
+# String errors (simple)
+result = Err("not found")  # Err[str]
+
+# Structured errors (recommended for complex apps)
+@dataclass
+class ValidationError:
+    field: str
+    message: str
+
+result = Err(ValidationError("email", "invalid format"))  # Err[ValidationError]
+```
+
+## Checking Variants
+
+### Methods
+
+```python
+result = Ok(42)
+
+result.is_ok()   # True
+result.is_err()  # False
+```
+
+### Type Guard Functions
+
+For proper type narrowing in early returns, use the standalone functions:
+
+```python
+from unwrappy import Ok, Err, Result, is_ok, is_err
+
+def process(data: str) -> Result[int, str]:
+    parsed = parse(data)  # Result[int, str]
+
+    if is_err(parsed):
+        return parsed  # Type checker knows this is Err[str]
+
+    # Type checker knows parsed is Ok[int] here
+    return Ok(parsed.unwrap() * 2)
+```
+
+!!! note "Why type guard functions?"
+    Python's type system doesn't narrow types based on method return values. The `is_ok()` and `is_err()` methods work at runtime, but the standalone `is_ok(result)` and `is_err(result)` functions use `TypeIs` for proper type narrowing.
+
+## Pattern Matching
+
+The recommended way to handle Results (Python 3.10+):
+
+```python
+from unwrappy import Ok, Err, Result
+
+def handle_result(result: Result[int, str]) -> str:
+    match result:
+        case Ok(value):
+            return f"Success: {value}"
+        case Err(error):
+            return f"Error: {error}"
+```
+
+Pattern matching with guards:
+
+```python
+match result:
+    case Ok(value) if value > 100:
+        return "Large success"
+    case Ok(value):
+        return f"Success: {value}"
+    case Err(error):
+        return f"Error: {error}"
+```
+
+## Extracting Values
+
+### Get Value or Raise
+
+```python
+Ok(42).unwrap()      # 42
+Err("oops").unwrap() # Raises UnwrapError
+```
+
+!!! danger "Use with caution"
+    `unwrap()` raises `UnwrapError` if called on an `Err`. Only use when you're certain the Result is `Ok`, or in tests.
+
+### Get Error or Raise
+
+```python
+Err("oops").unwrap_err()  # "oops"
+Ok(42).unwrap_err()       # Raises UnwrapError
+```
+
+### With Default
+
+```python
+Ok(42).unwrap_or(0)       # 42
+Err("oops").unwrap_or(0)  # 0
+```
+
+### With Computed Default
+
+```python
+Ok(42).unwrap_or_else(lambda e: len(e))       # 42
+Err("oops").unwrap_or_else(lambda e: len(e))  # 4
+```
+
+### Convert to Exception
+
+Perfect for API boundaries:
+
+```python
+from fastapi import HTTPException
+
+result = get_user(user_id)
+user = result.unwrap_or_raise(lambda e: HTTPException(404, e))
+```
+
+### With Custom Message
+
+```python
+Ok(42).expect("should have value")       # 42
+Err("oops").expect("should have value")  # Raises UnwrapError("should have value")
+```
+
+## Transformation Methods
+
+### Transform Ok Value
+
+```python
+Ok(5).map(lambda x: x * 2)      # Ok(10)
+Err("oops").map(lambda x: x * 2) # Err("oops") - unchanged
+```
+
+### Transform Err Value
+
+```python
+Ok(5).map_err(str.upper)         # Ok(5) - unchanged
+Err("oops").map_err(str.upper)   # Err("OOPS")
+```
+
+### Chain Result-Returning Functions
+
+Also known as "flatMap" or "bind" in functional programming:
+
+```python
+def validate_positive(n: int) -> Result[int, str]:
+    return Ok(n) if n > 0 else Err("must be positive")
+
+Ok(5).and_then(validate_positive)   # Ok(5)
+Ok(-5).and_then(validate_positive)  # Err("must be positive")
+Err("oops").and_then(validate_positive)  # Err("oops") - short-circuits
+```
+
+### Recover from Errors
+
+```python
+def try_backup(e: str) -> Result[int, str]:
+    return Ok(0)  # fallback value
+
+Err("oops").or_else(try_backup)  # Ok(0)
+Ok(5).or_else(try_backup)        # Ok(5) - unchanged
+```
+
+## Inspection Methods
+
+For side effects without changing the Result:
+
+### Inspect `Ok` Value
+
+```python
+result = (
+    Ok(42)
+    .tee(lambda x: print(f"Got: {x}"))  # Prints "Got: 42"
+    .map(lambda x: x * 2)
+)
+# result is Ok(84)
+```
+
+### Inspect `Err` Value
+
+```python
+result = (
+    Err("oops")
+    .inspect_err(lambda e: logger.error(f"Error: {e}"))
+    .or_else(recover)
+)
+```
+
+## Combining Results
+
+### Combine Two Results
+
+```python
+Ok(1).zip(Ok(2))      # Ok((1, 2))
+Ok(1).zip(Err("e"))   # Err("e")
+Err("e").zip(Ok(2))   # Err("e")
+```
+
+### Combine with Function
+
+```python
+Ok(10).zip_with(Ok(3), lambda a, b: a + b)  # Ok(13)
+```
+
+### Unwrap Nested Results
+
+```python
+Ok(Ok(42)).flatten()  # Ok(42)
+Ok(Err("e")).flatten() # Err("e")
+Err("e").flatten()    # Err("e")
+```
+
+### Keep `Ok` If Predicate Passes
+
+```python
+Ok(42).filter(lambda x: x > 0, "must be positive")  # Ok(42)
+Ok(-5).filter(lambda x: x > 0, "must be positive")  # Err("must be positive")
+```
+
+## Conversion Methods
+
+### Convert to `Option`
+
+```python
+Ok(42).ok()     # Some(42)
+Err("e").ok()   # NOTHING
+```
+
+### Convert Error to `Option`
+
+```python
+Ok(42).err()    # NOTHING
+Err("e").err()  # Some("e")
+```
+
+### Convert to Tuple
+
+```python
+Ok(42).split()    # (42, None)
+Err("e").split()  # (None, "e")
+```
+
+## Context and Error Chaining
+
+### Add Context to Errors
+
+```python
+result = (
+    parse_config("config.json")
+    .context("loading configuration")
+)
+# If parse_config returns Err("file not found")
+# Result is Err(ChainedError("loading configuration", "file not found"))
+```
+
+Chain multiple contexts:
+
+```python
+result = (
+    read_file(path)
+    .context("reading data file")
+    .and_then(parse_json)
+    .context("parsing JSON")
+    .and_then(validate_schema)
+    .context("validating schema")
+)
+# Error: "validating schema: parsing JSON: reading data file: ..."
+```
+
+## Async Methods
+
+All transformation methods have async variants:
+
+```python
+async def fetch_user(id: int) -> User:
+    ...
+
+result = await Ok(42).map_async(fetch_user)  # Ok(User(...))
+```
+
+Available async methods:
+
+- `map_async(fn)` - Transform with async function
+- `map_err_async(fn)` - Transform error with async function
+- `and_then_async(fn)` - Chain async Result-returning function
+- `or_else_async(fn)` - Recover with async function
+- `tee_async(fn)` / `inspect_async(fn)` - Async side effect on Ok
+- `inspect_err_async(fn)` - Async side effect on Err
+
+## Batch Operations
+
+### Collect Results
+
+Convert a list of Results into a Result of a list:
+
+```python
+from unwrappy import Ok, Err, sequence_results
+
+results = [Ok(1), Ok(2), Ok(3)]
+combined = sequence_results(results)  # Ok([1, 2, 3])
+
+results = [Ok(1), Err("e"), Ok(3)]
+combined = sequence_results(results)  # Err("e") - fails fast
+```
+
+### Map and Collect
+
+Map a function over items and collect Results:
+
+```python
+from unwrappy import traverse_results
+
+def parse_int(s: str) -> Result[int, str]:
+    try:
+        return Ok(int(s))
+    except ValueError:
+        return Err(f"invalid: {s}")
+
+items = ["1", "2", "3"]
+result = traverse_results(items, parse_int)  # Ok([1, 2, 3])
+
+items = ["1", "x", "3"]
+result = traverse_results(items, parse_int)  # Err("invalid: x")
+```
+
+## Best Practices
+
+### 1. Use Structured Errors
+
+Instead of string errors, use dataclasses or enums:
+
+```python
+from dataclasses import dataclass
+from enum import Enum
+
+class ErrorKind(Enum):
+    NOT_FOUND = "not_found"
+    VALIDATION = "validation"
+    PERMISSION = "permission"
+
+@dataclass
+class AppError:
+    kind: ErrorKind
+    message: str
+    details: dict | None = None
+
+def get_user(id: int) -> Result[User, AppError]:
+    if not exists(id):
+        return Err(AppError(ErrorKind.NOT_FOUND, f"User {id} not found"))
+    ...
+```
+
+### 2. Chain Operations
+
+Prefer chaining over nested conditionals:
+
+```python
+# Instead of this:
+result = parse(data)
+if result.is_ok():
+    result = validate(result.unwrap())
+    if result.is_ok():
+        result = transform(result.unwrap())
+
+# Do this:
+result = (
+    parse(data)
+    .and_then(validate)
+    .map(transform)
+)
+```
+
+### 3. Use Pattern Matching at Boundaries
+
+Handle Results explicitly at API/UI boundaries:
+
+```python
+@app.get("/users/{id}")
+def get_user_endpoint(id: int):
+    match user_service.get_user(id):
+        case Ok(user):
+            return user.to_dict()
+        case Err(AppError(kind=ErrorKind.NOT_FOUND)):
+            raise HTTPException(404, "User not found")
+        case Err(error):
+            raise HTTPException(500, error.message)
+```
+
+### 4. Use `tee()` for Logging
+
+```python
+result = (
+    fetch_data(url)
+    .tee(lambda d: logger.info(f"Fetched {len(d)} bytes"))
+    .and_then(parse)
+    .inspect_err(lambda e: logger.error(f"Parse failed: {e}"))
+)
+```

--- a/docs/guide/serialization.md
+++ b/docs/guide/serialization.md
@@ -1,0 +1,327 @@
+# Serialization
+
+unwrappy provides JSON serialization support for integration with task queues and distributed systems like Celery, Temporal, and DBOS.
+
+## Basic Usage
+
+### Using dumps/loads
+
+The simplest way to serialize unwrappy types:
+
+```python
+from unwrappy import Ok, Err, Some, NOTHING, dumps, loads
+
+# Serialize Result
+encoded = dumps(Ok(42))
+# '{"__unwrappy_type__": "Ok", "value": 42}'
+
+encoded = dumps(Err("not found"))
+# '{"__unwrappy_type__": "Err", "error": "not found"}'
+
+# Serialize Option
+encoded = dumps(Some("hello"))
+# '{"__unwrappy_type__": "Some", "value": "hello"}'
+
+encoded = dumps(NOTHING)
+# '{"__unwrappy_type__": "Nothing"}'
+
+# Deserialize
+decoded = loads(encoded)  # Returns the original type
+```
+
+### Using Standard json Module
+
+For more control, use the encoder and decoder directly:
+
+```python
+import json
+from unwrappy import Ok, ResultEncoder, result_decoder
+
+# Serialize
+encoded = json.dumps(Ok(42), cls=ResultEncoder)
+
+# Deserialize
+decoded = json.loads(encoded, object_hook=result_decoder)
+```
+
+## JSON Format
+
+unwrappy uses a tagged format for serialization:
+
+### Result Types
+
+```json
+// Ok
+{"__unwrappy_type__": "Ok", "value": <any JSON value>}
+
+// Err
+{"__unwrappy_type__": "Err", "error": <any JSON value>}
+```
+
+### Option Types
+
+```json
+// Some
+{"__unwrappy_type__": "Some", "value": <any JSON value>}
+
+// Nothing
+{"__unwrappy_type__": "Nothing"}
+```
+
+## Nested Serialization
+
+Complex nested structures are handled automatically:
+
+```python
+from unwrappy import Ok, Some, dumps, loads
+
+# Nested structures
+data = Ok({
+    "user": {"name": "Alice", "age": 30},
+    "settings": Some({"theme": "dark"})
+})
+
+encoded = dumps(data)
+decoded = loads(encoded)
+
+# decoded is Ok({"user": {...}, "settings": Some({...})})
+```
+
+## LazyResult Limitation
+
+!!! danger "LazyResult/LazyOption cannot be serialized"
+    Lazy types contain function references that cannot be converted to JSON.
+
+    ```python
+    from unwrappy import LazyResult, dumps
+
+    lazy = LazyResult.ok(42).map(lambda x: x * 2)
+
+    # This raises TypeError!
+    dumps(lazy)
+    ```
+
+    **Solution**: Always call `.collect()` first:
+
+    ```python
+    result = await lazy.collect()
+    dumps(result)  # Works!
+    ```
+
+## Framework Integration
+
+### Celery
+
+Register a custom serializer for Celery tasks:
+
+```python
+from kombu.serialization import register
+from unwrappy.serde import dumps, loads
+
+# Register the serializer
+register(
+    'unwrappy-json',
+    dumps,
+    loads,
+    content_type='application/x-unwrappy-json',
+    content_encoding='utf-8'
+)
+
+# Configure Celery to use it
+app.conf.update(
+    task_serializer='unwrappy-json',
+    result_serializer='unwrappy-json',
+    accept_content=['unwrappy-json'],
+)
+```
+
+Now your tasks can return Result types:
+
+```python
+from unwrappy import Ok, Err, Result
+
+@app.task
+def process_data(data: dict) -> Result[dict, str]:
+    try:
+        processed = transform(data)
+        return Ok(processed)
+    except ValueError as e:
+        return Err(str(e))
+```
+
+### Temporal
+
+Create a custom data converter for Temporal workflows:
+
+```python
+from temporalio.converter import (
+    DataConverter,
+    JSONPlainPayloadConverter,
+)
+from unwrappy.serde import ResultEncoder, result_decoder
+import json
+
+class UnwrappyJSONPayloadConverter(JSONPlainPayloadConverter):
+    def encode(self, value):
+        return json.dumps(value, cls=ResultEncoder).encode()
+
+    def decode(self, data, type_hint=None):
+        return json.loads(data.decode(), object_hook=result_decoder)
+
+# Use in your Temporal client
+client = await Client.connect(
+    "localhost:7233",
+    data_converter=DataConverter(
+        payload_converters=[UnwrappyJSONPayloadConverter()]
+    )
+)
+```
+
+### DBOS
+
+Create a custom serializer for DBOS workflows:
+
+```python
+from dbos import DBOS
+from unwrappy.serde import dumps, loads
+
+class UnwrappySerializer:
+    def serialize(self, obj) -> str:
+        return dumps(obj)
+
+    def deserialize(self, data: str):
+        return loads(data)
+
+# Configure DBOS
+DBOS.set_serializer(UnwrappySerializer())
+```
+
+### FastAPI Response Models
+
+For API responses, convert to dict before returning:
+
+```python
+from fastapi import FastAPI
+from unwrappy import Ok, Err, Result
+
+app = FastAPI()
+
+@app.get("/users/{user_id}")
+def get_user(user_id: int) -> dict:
+    result: Result[User, str] = user_service.get(user_id)
+
+    match result:
+        case Ok(user):
+            return {"status": "ok", "data": user.dict()}
+        case Err(error):
+            return {"status": "error", "message": error}
+```
+
+Or use `unwrap_or_raise` for cleaner code:
+
+```python
+from fastapi import HTTPException
+
+@app.get("/users/{user_id}")
+def get_user(user_id: int) -> dict:
+    user = user_service.get(user_id).unwrap_or_raise(
+        lambda e: HTTPException(404, e)
+    )
+    return user.dict()
+```
+
+## Custom Serialization
+
+### Extending for Custom Types
+
+If you have custom types inside Results, ensure they're JSON-serializable:
+
+```python
+from dataclasses import dataclass, asdict
+from unwrappy import Ok, dumps
+import json
+
+@dataclass
+class User:
+    id: int
+    name: str
+
+    def to_dict(self):
+        return asdict(self)
+
+# Option 1: Convert before serializing
+user = User(1, "Alice")
+dumps(Ok(user.to_dict()))
+
+# Option 2: Custom encoder
+class CustomEncoder(ResultEncoder):
+    def default(self, obj):
+        if isinstance(obj, User):
+            return obj.to_dict()
+        return super().default(obj)
+
+json.dumps(Ok(user), cls=CustomEncoder)
+```
+
+### Pydantic Integration
+
+With Pydantic models:
+
+```python
+from pydantic import BaseModel
+from unwrappy import Ok, dumps
+
+class User(BaseModel):
+    id: int
+    name: str
+
+user = User(id=1, name="Alice")
+
+# Pydantic models have .model_dump()
+dumps(Ok(user.model_dump()))
+```
+
+## Error Handling
+
+The decoder gracefully handles non-unwrappy JSON:
+
+```python
+from unwrappy import loads
+
+# Regular JSON passes through unchanged
+loads('{"name": "Alice"}')  # Returns {"name": "Alice"}
+
+# Only tagged objects become unwrappy types
+loads('{"__unwrappy_type__": "Ok", "value": 42}')  # Returns Ok(42)
+```
+
+## Best Practices
+
+1. **Always collect LazyResult before serializing**
+   ```python
+   result = await lazy.collect()
+   encoded = dumps(result)
+   ```
+
+2. **Use structured errors for better debugging**
+   ```python
+   @dataclass
+   class AppError:
+       code: str
+       message: str
+
+   # Serializes cleanly
+   dumps(Err(AppError("NOT_FOUND", "User not found").__dict__))
+   ```
+
+3. **Validate after deserialization**
+   ```python
+   decoded = loads(data)
+   if not isinstance(decoded, (Ok, Err)):
+       raise ValueError("Expected Result type")
+   ```
+
+4. **Consider versioning for production systems**
+   ```python
+   encoded = dumps({"version": 1, "result": Ok(data)})
+   ```

--- a/docs/includes/abbreviations.md
+++ b/docs/includes/abbreviations.md
@@ -1,0 +1,11 @@
+*[Result]: A type representing either success (Ok) or failure (Err)
+*[Option]: A type representing an optional value: Some(value) or Nothing
+*[Ok]: The success variant of Result, containing a value
+*[Err]: The error variant of Result, containing an error
+*[Some]: The present variant of Option, containing a value
+*[Nothing]: The absent variant of Option (singleton)
+*[LazyResult]: Deferred execution wrapper for async Result chains
+*[LazyOption]: Deferred execution wrapper for async Option chains
+*[combinator]: A method that transforms or chains Result/Option values
+*[unwrap]: Extract the inner value, raising an error if the variant doesn't match
+*[pattern matching]: Python 3.10+ structural pattern matching (match/case)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,197 @@
+---
+hide:
+  - navigation
+---
+
+# unwrappy
+
+**Rust-inspired `Result` and `Option` types for Python**
+
+Safe, expressive error handling with errors as values.
+
+---
+
+<div class="grid cards" markdown>
+
+-   :material-check-circle:{ .lg .middle } **Explicit Error Handling**
+
+    ---
+
+    No hidden exceptions. Errors are values that must be handled, making your code's error paths visible and type-checkable.
+
+-   :material-shield-check:{ .lg .middle } **Type Safe**
+
+    ---
+
+    Full generic type support with proper inference. Works with pyright, mypy, and ty out of the box.
+
+-   :material-function:{ .lg .middle } **Functional Composition**
+
+    ---
+
+    Rich combinator API (`map`, `and_then`, `or_else`, etc.) for elegant transformation chains.
+
+-   :material-lightning-bolt:{ .lg .middle } **Async First**
+
+    ---
+
+    `LazyResult` and `LazyOption` for clean async operation chaining without nested awaits.
+
+</div>
+
+## Quick Example
+
+```python
+from unwrappy import Ok, Err, Result
+
+def divide(a: int, b: int) -> Result[float, str]:
+    if b == 0:
+        return Err("division by zero")
+    return Ok(a / b)
+
+# Pattern matching (Python 3.10+)
+match divide(10, 2):
+    case Ok(value):
+        print(f"Result: {value}")
+    case Err(error):
+        print(f"Error: {error}")
+
+# Combinator chaining
+result = (
+    divide(10, 2)
+    .map(lambda x: x * 2)
+    .and_then(lambda x: Ok(int(x)) if x < 100 else Err("too large"))
+)
+```
+
+## Installation
+
+```bash
+pip install unwrappy
+```
+
+Or with uv:
+
+```bash
+uv add unwrappy
+```
+
+## Why unwrappy?
+
+Python's exception-based error handling has fundamental issues for complex applications:
+
+| Problem | With Exceptions | With unwrappy |
+|---------|-----------------|---------------|
+| **Hidden control flow** | Exceptions can be raised anywhere and caught anywhere | Errors are explicit values in function signatures |
+| **Unclear contracts** | Function signatures don't declare what exceptions they raise | Return types show exactly what can fail |
+| **Silent failures** | Forgotten exception handling leads to runtime crashes | Type checker enforces handling |
+
+unwrappy provides `Result[T, E]` and `Option[T]` types that make errors **explicit values** in your code.
+
+## Core Types
+
+### Result[T, E]
+
+Represents either success (`Ok`) or failure (`Err`):
+
+```python
+from unwrappy import Ok, Err, Result
+
+def parse_int(s: str) -> Result[int, str]:
+    try:
+        return Ok(int(s))
+    except ValueError:
+        return Err(f"invalid number: {s}")
+
+result = parse_int("42")
+result.unwrap()      # 42
+result.is_ok()       # True
+```
+
+[Learn more about Result :material-arrow-right:](guide/result.md){ .md-button }
+
+### Option[T]
+
+Represents an optional value (`Some` or `Nothing`):
+
+```python
+from unwrappy import Some, NOTHING, Option, from_nullable
+
+def find_user(user_id: int) -> Option[User]:
+    user = db.get(user_id)  # Returns User | None
+    return from_nullable(user)
+
+email = find_user(123).map(lambda u: u.email).unwrap_or("unknown")
+```
+
+[Learn more about Option :material-arrow-right:](guide/option.md){ .md-button }
+
+### LazyResult & LazyOption
+
+Deferred execution for clean async chaining:
+
+```python
+from unwrappy import LazyResult
+
+async def fetch_user(id: int) -> Result[User, str]: ...
+async def fetch_profile(user: User) -> Result[Profile, str]: ...
+
+# Build pipeline, execute once - no nested awaits!
+result = await (
+    LazyResult.from_awaitable(fetch_user(42))
+    .and_then(fetch_profile)
+    .map(lambda p: p.name)
+    .collect()
+)
+```
+
+[Learn more about Lazy Evaluation :material-arrow-right:](guide/lazy-evaluation.md){ .md-button }
+
+## Design Philosophy
+
+unwrappy is designed for **practical use** in real Python codebases:
+
+- **Zero dependencies** - Just Python stdlib
+- **Incremental adoption** - Use in a single module or throughout your codebase
+- **Framework friendly** - Works alongside FastAPI, Django, Flask, etc.
+- **No magic** - No decorators, no metaclasses, no import hooks
+
+[Read the Architecture docs :material-arrow-right:](architecture.md){ .md-button .md-button--primary }
+
+## Next Steps
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch:{ .lg .middle } **Getting Started**
+
+    ---
+
+    Installation, basic usage, and your first Result-based function.
+
+    [:octicons-arrow-right-24: Get started](getting-started.md)
+
+-   :material-book-open-variant:{ .lg .middle } **Guide**
+
+    ---
+
+    Deep dive into Result, Option, and async patterns.
+
+    [:octicons-arrow-right-24: Read the guide](guide/result.md)
+
+-   :material-api:{ .lg .middle } **API Reference**
+
+    ---
+
+    Complete API documentation with all methods and functions.
+
+    [:octicons-arrow-right-24: API docs](api/result.md)
+
+-   :material-code-tags:{ .lg .middle } **Examples**
+
+    ---
+
+    Real-world patterns and code examples.
+
+    [:octicons-arrow-right-24: View examples](examples.md)
+
+</div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,602 @@
+/*
+ * Sharp Solarized Theme for unwrappy
+ *
+ * Based on Sharp Solarized Zed theme by tinytinytinytiny and Josh Spicer.
+ * A warm, paper-like, high-contrast light theme with burnt red accents.
+ */
+
+/* ==========================================================================
+   Sharp Solarized Color Palette
+   ==========================================================================
+   Backgrounds (light to dark):
+   - #fcfaf3 - brightest (hover, active line)
+   - #f7f4e8 - editor background (paper white)
+   - #ebe6d6 - surface, panels (cream)
+   - #d2ccb8 - sidebar, tab bar (tan/beige)
+
+   Text:
+   - #000000 - primary text (pure black)
+   - #767470 - muted text, comments
+   - #ada68f - placeholder, line numbers
+
+   Accents:
+   - #423e31 - dark brown (headers, active elements)
+   - #b02402 - burnt red (links, strings, accent)
+
+   Borders:
+   - #232018 - primary border (very dark)
+   - #d2ccb8 - light border
+   - #cbc9c3 - disabled border
+
+   Semantic:
+   - #cd3131 - error, red
+   - #147641 - success, green
+   - #cd9731 - warning, yellow
+   - #316bcd - info, blue
+
+   Syntax:
+   - #978d72 - brackets (muted tan)
+   ========================================================================== */
+
+:root {
+  /* Sharp Solarized Palette */
+  --sharp-bg-brightest: #fcfaf3;
+  --sharp-bg-editor: #f7f4e8;
+  --sharp-bg-surface: #ebe6d6;
+  --sharp-bg-sidebar: #d2ccb8;
+
+  --sharp-text: #000000;
+  --sharp-text-muted: #767470;
+  --sharp-text-placeholder: #ada68f;
+
+  --sharp-accent-brown: #423e31;
+  --sharp-accent-red: #b02402;
+
+  --sharp-border-dark: #232018;
+  --sharp-border-light: #d2ccb8;
+  --sharp-border-disabled: #cbc9c3;
+
+  --sharp-red: #cd3131;
+  --sharp-green: #147641;
+  --sharp-yellow: #cd9731;
+  --sharp-blue: #316bcd;
+
+  --sharp-bracket: #978d72;
+
+  /* Warm Paper Dark mode */
+  --sharp-dark-bg: #2a2722;
+  --sharp-dark-surface: #353230;
+  --sharp-dark-elevated: #403c38;
+  --sharp-dark-hover: #4a4642;
+  --sharp-dark-text: #ebe6d6;
+  --sharp-dark-text-secondary: #d2ccb8;
+  --sharp-dark-accent: #d4836a;
+  --sharp-dark-accent-hover: #e09880;
+}
+
+/* ==========================================================================
+   Light Mode - Sharp Solarized
+   ========================================================================== */
+
+[data-md-color-scheme="solarized-light"] {
+  /* Background colors - warm paper tones */
+  --md-default-bg-color: #f7f4e8;
+  --md-default-bg-color--light: #ebe6d6;
+  --md-default-bg-color--lighter: #fcfaf3;
+  --md-default-bg-color--lightest: #fcfaf3;
+
+  /* Foreground/text colors - high contrast black */
+  --md-default-fg-color: #000000;
+  --md-default-fg-color--light: #767470;
+  --md-default-fg-color--lighter: #ada68f;
+  --md-default-fg-color--lightest: #cbc9c3;
+
+  /* Primary color - Dark brown (headers, active elements) */
+  --md-primary-fg-color: #423e31;
+  --md-primary-fg-color--light: #5a554a;
+  --md-primary-fg-color--dark: #232018;
+  --md-primary-bg-color: #ffffff;
+  --md-primary-bg-color--light: #f7f4e8;
+
+  /* Accent color - Burnt red (links, highlights) */
+  --md-accent-fg-color: #b02402;
+  --md-accent-fg-color--transparent: rgba(176, 36, 2, 0.1);
+  --md-accent-bg-color: #f7f4e8;
+  --md-accent-bg-color--light: #fcfaf3;
+
+  /* Code blocks */
+  --md-code-fg-color: #000000;
+  --md-code-bg-color: #ebe6d6;
+  --md-code-hl-color: rgba(66, 62, 49, 0.15);
+  --md-code-hl-number-color: #000000;
+  --md-code-hl-special-color: #b02402;
+  --md-code-hl-function-color: #000000;
+  --md-code-hl-constant-color: #000000;
+  --md-code-hl-keyword-color: #000000;
+  --md-code-hl-string-color: #b02402;
+  --md-code-hl-name-color: #000000;
+  --md-code-hl-operator-color: #000000;
+  --md-code-hl-punctuation-color: #978d72;
+  --md-code-hl-comment-color: #767470;
+  --md-code-hl-generic-color: #000000;
+  --md-code-hl-variable-color: #000000;
+
+  /* Typeset links */
+  --md-typeset-a-color: #b02402;
+
+  /* Footer */
+  --md-footer-bg-color: #423e31;
+  --md-footer-bg-color--dark: #232018;
+  --md-footer-fg-color: #f8f3e8;
+  --md-footer-fg-color--light: #ebe6d6;
+  --md-footer-fg-color--lighter: #d2ccb8;
+
+  /* Tables */
+  --md-typeset-table-color: rgba(0, 0, 0, 0.05);
+
+  /* Admonitions */
+  --md-admonition-bg-color: #ebe6d6;
+}
+
+/* ==========================================================================
+   Dark Mode - Warm Paper Dark
+   A cozy dark theme with warm brown backgrounds and cream text.
+   Like reading aged paper by candlelight.
+   ========================================================================== */
+
+[data-md-color-scheme="slate"] {
+  /* Background colors - warm brown tones */
+  --md-default-bg-color: #2a2722;
+  --md-default-bg-color--light: #353230;
+  --md-default-bg-color--lighter: #403c38;
+  --md-default-bg-color--lightest: #4a4642;
+
+  /* Foreground/text colors - cream/beige (inverted from light mode) */
+  --md-default-fg-color: #ebe6d6;
+  --md-default-fg-color--light: #d2ccb8;
+  --md-default-fg-color--lighter: #ada68f;
+  --md-default-fg-color--lightest: #867f6f;
+
+  /* Primary color - Soft coral (warm, readable) */
+  --md-primary-fg-color: #d4836a;
+  --md-primary-fg-color--light: #e09880;
+  --md-primary-fg-color--dark: #b86d55;
+  --md-primary-bg-color: #2a2722;
+  --md-primary-bg-color--light: #353230;
+
+  /* Accent color - Soft coral for links */
+  --md-accent-fg-color: #d4836a;
+  --md-accent-fg-color--transparent: rgba(212, 131, 106, 0.15);
+  --md-accent-bg-color: #2a2722;
+  --md-accent-bg-color--light: #353230;
+
+  /* Code blocks */
+  --md-code-fg-color: #ebe6d6;
+  --md-code-bg-color: #232018;
+  --md-code-hl-color: rgba(212, 131, 106, 0.15);
+  --md-code-hl-number-color: #ebe6d6;
+  --md-code-hl-special-color: #d4836a;
+  --md-code-hl-function-color: #ebe6d6;
+  --md-code-hl-constant-color: #ebe6d6;
+  --md-code-hl-keyword-color: #ebe6d6;
+  --md-code-hl-string-color: #d4836a;
+  --md-code-hl-name-color: #ebe6d6;
+  --md-code-hl-operator-color: #d2ccb8;
+  --md-code-hl-punctuation-color: #ada68f;
+  --md-code-hl-comment-color: #867f6f;
+  --md-code-hl-generic-color: #ebe6d6;
+  --md-code-hl-variable-color: #ebe6d6;
+
+  /* Typeset links */
+  --md-typeset-a-color: #d4836a;
+
+  /* Footer - slightly darker than main bg */
+  --md-footer-bg-color: #232018;
+  --md-footer-bg-color--dark: #1a1712;
+  --md-footer-fg-color: #ebe6d6;
+  --md-footer-fg-color--light: #d2ccb8;
+  --md-footer-fg-color--lighter: #ada68f;
+
+  /* Tables */
+  --md-typeset-table-color: rgba(235, 230, 214, 0.05);
+
+  /* Admonitions */
+  --md-admonition-bg-color: #232018;
+}
+
+/* ==========================================================================
+   Typography & General Styles
+   ========================================================================== */
+
+/* Sharp, high-contrast headings */
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4 {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.md-typeset h1 {
+  color: var(--md-primary-fg-color);
+}
+
+/* Code styling */
+.md-typeset code {
+  border-radius: 2px;
+  font-weight: 500;
+}
+
+.md-typeset pre {
+  border-radius: 0;
+  border-left: 3px solid var(--md-primary-fg-color);
+}
+
+[data-md-color-scheme="slate"] .md-typeset pre {
+  border-left-color: #d4836a;
+}
+
+/* Remove left border from code blocks inside admonitions */
+.md-typeset .admonition pre,
+.md-typeset details pre {
+  border-left: none;
+}
+
+/* Bold keywords in code (matching Zed theme) */
+.md-typeset .highlight .k,   /* keyword */
+.md-typeset .highlight .kn,  /* keyword namespace */
+.md-typeset .highlight .kd,  /* keyword declaration */
+.md-typeset .highlight .kc,  /* keyword constant */
+.md-typeset .highlight .bp   /* boolean/builtin pseudo */ {
+  font-weight: 700;
+}
+
+/* Italic comments */
+.md-typeset .highlight .c,   /* comment */
+.md-typeset .highlight .c1,  /* comment single */
+.md-typeset .highlight .cm,  /* comment multiline */
+.md-typeset .highlight .cs   /* comment special */ {
+  font-style: italic;
+}
+
+/* Table styling - Sharp Solarized look */
+.md-typeset table:not([class]) {
+  border: 1px solid var(--sharp-border-light);
+  border-radius: 0;
+}
+
+.md-typeset table:not([class]) th {
+  background-color: var(--md-primary-fg-color);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) th {
+  background-color: #403c38;
+  color: #ebe6d6;
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) td {
+  border-color: #353230;
+}
+
+.md-typeset table:not([class]) td {
+  border-color: var(--sharp-border-light);
+}
+
+/* ==========================================================================
+   Header - Dark brown like active tab
+   ========================================================================== */
+
+/* Unified top bar for both light and dark mode */
+.md-header {
+  background-color: #2a2722;
+}
+
+.md-tabs {
+  background-color: #2a2722;
+}
+
+.md-tabs__link {
+  color: #d2ccb8;
+}
+
+.md-tabs__link--active,
+.md-tabs__link:hover {
+  color: #ebe6d6;
+}
+
+/* Header text and icons - same for both modes */
+.md-header__title,
+.md-header__topic,
+.md-header__ellipsis,
+.md-header .md-logo,
+.md-header__button,
+.md-header__source,
+.md-header [data-md-component="source"],
+.md-header .md-icon,
+.md-header svg {
+  color: #ebe6d6;
+  fill: #ebe6d6;
+}
+
+.md-header__option,
+.md-header__button:hover {
+  color: #d4836a;
+}
+
+.md-header__title {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+/* Search bar - same for both modes */
+.md-search__input {
+  background-color: #353230;
+  color: #ebe6d6;
+}
+
+.md-search__input::placeholder {
+  color: #ada68f;
+}
+
+/* ==========================================================================
+   Navigation
+   ========================================================================== */
+
+.md-nav__link--active,
+.md-nav__link:hover {
+  color: var(--md-accent-fg-color);
+}
+
+.md-tabs__link--active,
+.md-tabs__link:hover {
+  color: var(--md-accent-fg-color);
+}
+
+/* Active tab styling */
+.md-tabs__link--active {
+  border-bottom: 2px solid var(--md-accent-fg-color);
+}
+
+/* ==========================================================================
+   Admonitions
+   ========================================================================== */
+
+/* Note - Blue */
+.md-typeset .admonition.note,
+.md-typeset details.note {
+  border-color: #316bcd;
+}
+
+.md-typeset .note > .admonition-title,
+.md-typeset .note > summary {
+  background-color: rgba(49, 107, 205, 0.1);
+  border-color: #316bcd;
+}
+
+.md-typeset .note > .admonition-title::before,
+.md-typeset .note > summary::before {
+  background-color: #316bcd;
+}
+
+/* Tip - Green */
+.md-typeset .admonition.tip,
+.md-typeset details.tip {
+  border-color: #147641;
+}
+
+.md-typeset .tip > .admonition-title,
+.md-typeset .tip > summary {
+  background-color: rgba(20, 118, 65, 0.1);
+  border-color: #147641;
+}
+
+.md-typeset .tip > .admonition-title::before,
+.md-typeset .tip > summary::before {
+  background-color: #147641;
+}
+
+/* Warning - Yellow */
+.md-typeset .admonition.warning,
+.md-typeset details.warning {
+  border-color: #cd9731;
+}
+
+.md-typeset .warning > .admonition-title,
+.md-typeset .warning > summary {
+  background-color: rgba(205, 151, 49, 0.1);
+  border-color: #cd9731;
+}
+
+.md-typeset .warning > .admonition-title::before,
+.md-typeset .warning > summary::before {
+  background-color: #cd9731;
+}
+
+/* Danger - Red */
+.md-typeset .admonition.danger,
+.md-typeset details.danger {
+  border-color: #cd3131;
+}
+
+.md-typeset .danger > .admonition-title,
+.md-typeset .danger > summary {
+  background-color: rgba(205, 49, 49, 0.1);
+  border-color: #cd3131;
+}
+
+.md-typeset .danger > .admonition-title::before,
+.md-typeset .danger > summary::before {
+  background-color: #cd3131;
+}
+
+/* Example - Dark brown */
+.md-typeset .admonition.example,
+.md-typeset details.example {
+  border-color: #423e31;
+}
+
+.md-typeset .example > .admonition-title,
+.md-typeset .example > summary {
+  background-color: rgba(66, 62, 49, 0.1);
+  border-color: #423e31;
+}
+
+.md-typeset .example > .admonition-title::before,
+.md-typeset .example > summary::before {
+  background-color: #423e31;
+}
+
+/* Info - Blue */
+.md-typeset .admonition.info,
+.md-typeset details.info {
+  border-color: #316bcd;
+}
+
+.md-typeset .info > .admonition-title,
+.md-typeset .info > summary {
+  background-color: rgba(49, 107, 205, 0.1);
+  border-color: #316bcd;
+}
+
+.md-typeset .info > .admonition-title::before,
+.md-typeset .info > summary::before {
+  background-color: #316bcd;
+}
+
+/* Important - Burnt red */
+.md-typeset .admonition.important,
+.md-typeset details.important {
+  border-color: #b02402;
+}
+
+.md-typeset .important > .admonition-title,
+.md-typeset .important > summary {
+  background-color: rgba(176, 36, 2, 0.1);
+  border-color: #b02402;
+}
+
+.md-typeset .important > .admonition-title::before,
+.md-typeset .important > summary::before {
+  background-color: #b02402;
+}
+
+/* ==========================================================================
+   Buttons
+   ========================================================================== */
+
+.md-typeset .md-button {
+  border-radius: 0;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  border-width: 2px;
+}
+
+.md-typeset .md-button--primary {
+  background-color: var(--md-primary-fg-color);
+  border-color: var(--md-primary-fg-color);
+  color: #ffffff;
+}
+
+.md-typeset .md-button--primary:hover {
+  background-color: var(--md-primary-fg-color--dark);
+  border-color: var(--md-primary-fg-color--dark);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .md-button--primary {
+  background-color: #d4836a;
+  border-color: #d4836a;
+  color: #232018;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .md-button--primary:hover {
+  background-color: #e09880;
+  border-color: #e09880;
+}
+
+/* ==========================================================================
+   Footer
+   ========================================================================== */
+
+.md-footer {
+  background-color: var(--md-footer-bg-color);
+}
+
+.md-footer-meta {
+  background-color: var(--md-footer-bg-color--dark);
+}
+
+/* ==========================================================================
+   Scrollbar (matches Zed theme)
+   ========================================================================== */
+
+.md-sidebar__scrollwrap {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(66, 62, 49, 0.3) transparent;
+}
+
+[data-md-color-scheme="slate"] .md-sidebar__scrollwrap {
+  scrollbar-color: rgba(248, 243, 232, 0.3) transparent;
+}
+
+/* ==========================================================================
+   API Documentation (mkdocstrings)
+   ========================================================================== */
+
+.doc-heading {
+  border-bottom: 2px solid var(--md-primary-fg-color);
+  padding-bottom: 0.5rem;
+}
+
+.doc-signature {
+  background-color: var(--md-code-bg-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0;
+  border-left: 3px solid var(--md-primary-fg-color);
+}
+
+.doc-section-title {
+  color: var(--md-primary-fg-color);
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+}
+
+/* ==========================================================================
+   Cards (for landing page grid)
+   ========================================================================== */
+
+.md-typeset .grid.cards > ul > li {
+  border: 1px solid var(--sharp-border-light);
+  border-radius: 0;
+}
+
+.md-typeset .grid.cards > ul > li:hover {
+  border-color: var(--md-primary-fg-color);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .grid.cards > ul > li {
+  border-color: #353230;
+  background-color: #353230;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .grid.cards > ul > li:hover {
+  border-color: #d4836a;
+}
+
+/* ==========================================================================
+   Content tabs
+   ========================================================================== */
+
+.md-typeset .tabbed-labels > label {
+  border-radius: 0;
+}
+
+.md-typeset .tabbed-labels > label:hover {
+  color: var(--md-accent-fg-color);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,152 @@
+site_name: unwrappy
+site_url: https://leodiegues.github.io/unwrappy
+site_description: Rust-inspired Result and Option types for Python - safe, expressive error handling with errors as values
+site_author: Leonardo Diegues
+repo_name: leodiegues/unwrappy
+repo_url: https://github.com/leodiegues/unwrappy
+edit_uri: edit/main/docs/
+
+copyright: Copyright &copy; 2024 Leonardo Diegues
+
+theme:
+  name: material
+  custom_dir: docs/overrides
+  logo: assets/logo.svg
+  favicon: assets/logo.svg
+  palette:
+    # Light mode - Sharp Solarized (sepia/rust tones)
+    - media: "(prefers-color-scheme: light)"
+      scheme: solarized-light
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Dark mode - Solarized Dark with rust accents
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: Roboto
+    code: Roboto Mono
+  features:
+    - navigation.instant
+    - navigation.instant.prefetch
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.expand
+    - navigation.indexes
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+extra_css:
+  - stylesheets/extra.css
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/leodiegues/unwrappy
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/unwrappy/
+  generator: false
+
+markdown_extensions:
+  # Python Markdown
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      toc_depth: 3
+
+  # PyMdown Extensions
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.snippets:
+      auto_append:
+        - includes/abbreviations.md
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            docstring_section_style: spacy
+            show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            show_signature_annotations: true
+            separate_signature: true
+            signature_crossrefs: true
+            merge_init_into_class: true
+            show_if_no_docstring: false
+  - social:
+      cards_layout_options:
+        background_color: "#b58900"
+        color: "#fdf6e3"
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Guide:
+      - guide/index.md
+      - Result Type: guide/result.md
+      - Option Type: guide/option.md
+      - Lazy Evaluation: guide/lazy-evaluation.md
+      - Serialization: guide/serialization.md
+  - API Reference:
+      - api/index.md
+      - Result: api/result.md
+      - Option: api/option.md
+  - Examples: examples.md
+  - Architecture: architecture.md
+  - Contributing: contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 [project.urls]
 Repository = "https://github.com/leodiegues/unwrappy"
-Documentation = "https://github.com/leodiegues/unwrappy#readme"
+Documentation = "https://leodiegues.github.io/unwrappy"
 Changelog = "https://github.com/leodiegues/unwrappy/releases"
 
 [build-system]
@@ -44,6 +44,12 @@ dev = [
     "ruff>=0.14.11",
     "ty>=0.0.11",
     "typing-extensions>=4.12.0",
+]
+docs = [
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.27",
+    "pillow>=10.0",
+    "cairosvg>=2.7",
 ]
 
 [tool.ruff]

--- a/src/unwrappy/__init__.py
+++ b/src/unwrappy/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from importlib.metadata import version
 
-from unwrappy.exceptions import ChainedError
+from unwrappy.exceptions import ChainedError, UnwrapError
 from unwrappy.option import (
     NOTHING,
     LazyOption,
@@ -42,6 +42,7 @@ __all__ = [
     "is_some",
     "is_nothing",
     # Errors
+    "UnwrapError",
     "ChainedError",
     # Serialization
     "ResultEncoder",

--- a/src/unwrappy/option.py
+++ b/src/unwrappy/option.py
@@ -30,11 +30,11 @@ class Some(Generic[T]):
         value: The value to wrap.
 
     Example:
-        >>> option = Some(42)
-        >>> option.unwrap()
-        42
-        >>> option.is_some()
-        True
+        ```python
+        option = Some(42)
+        option.unwrap()  # 42
+        option.is_some()  # True
+        ```
     """
 
     __slots__ = ("_value",)
@@ -184,11 +184,11 @@ class _NothingType:
     This is a singleton class. Use the NOTHING constant.
 
     Example:
-        >>> option = NOTHING
-        >>> option.is_nothing()
-        True
-        >>> option.unwrap_or(0)
-        0
+        ```python
+        option = NOTHING
+        option.is_nothing()  # True
+        option.unwrap_or(0)  # 0
+        ```
     """
 
     __slots__ = ()
@@ -416,19 +416,22 @@ class LazyOption(Generic[T]):
         T: The value type.
 
     Example:
-        >>> async def fetch_config(key: str) -> Option[str]: ...
-        >>>
-        >>> result = await (
-        ...     LazyOption.from_awaitable(fetch_config("api_key"))
-        ...     .map(str.upper)
-        ...     .filter(lambda s: len(s) > 0)
-        ...     .collect()
-        ... )
+        ```python
+        async def fetch_config(key: str) -> Option[str]: ...
+
+        result = await (
+            LazyOption.from_awaitable(fetch_config("api_key"))
+            .map(str.upper)
+            .filter(lambda s: len(s) > 0)
+            .collect()
+        )
+        ```
 
     From an existing Option:
-        >>> result = await Some(5).lazy().map(lambda x: x * 2).collect()
-        >>> result
-        Some(10)
+        ```python
+        result = await Some(5).lazy().map(lambda x: x * 2).collect()
+        result  # Some(10)
+        ```
     """
 
     __slots__ = ("_source", "_operations")
@@ -549,12 +552,11 @@ def sequence_options(options: Iterable[Some[T] | _NothingType]) -> Some[list[T]]
         Some(list) if all are Some, otherwise Nothing.
 
     Example:
-        >>> sequence_options([Some(1), Some(2), Some(3)])
-        Some([1, 2, 3])
-        >>> sequence_options([Some(1), NOTHING, Some(3)])
-        Nothing
-        >>> sequence_options([])
-        Some([])
+        ```python
+        sequence_options([Some(1), Some(2), Some(3)])  # Some([1, 2, 3])
+        sequence_options([Some(1), NOTHING, Some(3)])  # Nothing
+        sequence_options([])  # Some([])
+        ```
     """
     values: list[T] = []
     for opt in options:
@@ -578,12 +580,13 @@ def traverse_options(items: Iterable[U], fn: Callable[[U], Some[T] | _NothingTyp
         Some(list) if all succeed, otherwise Nothing.
 
     Example:
-        >>> def safe_sqrt(x: float) -> Option[float]:
-        ...     return Some(x ** 0.5) if x >= 0 else NOTHING
-        >>> traverse_options([4, 9, 16], safe_sqrt)
-        Some([2.0, 3.0, 4.0])
-        >>> traverse_options([4, -1, 16], safe_sqrt)
-        Nothing
+        ```python
+        def safe_sqrt(x: float) -> Option[float]:
+            return Some(x ** 0.5) if x >= 0 else NOTHING
+
+        traverse_options([4, 9, 16], safe_sqrt)  # Some([2.0, 3.0, 4.0])
+        traverse_options([4, -1, 16], safe_sqrt)  # Nothing
+        ```
     """
     return sequence_options(fn(item) for item in items)
 
@@ -598,10 +601,10 @@ def from_nullable(value: T | None) -> Some[T] | _NothingType:
         Some(value) if value is not None, otherwise Nothing.
 
     Example:
-        >>> from_nullable(42)
-        Some(42)
-        >>> from_nullable(None)
-        Nothing
+        ```python
+        from_nullable(42)    # Some(42)
+        from_nullable(None)  # Nothing
+        ```
     """
     if value is None:
         return NOTHING
@@ -623,11 +626,14 @@ def is_some(option: Some[T] | _NothingType) -> TypeIs[Some[T]]:
         True if option is Some, with the type narrowed to Some[T].
 
     Example:
-        >>> from unwrappy import Option, Some, Nothing, is_some
-        >>> def get_value(opt: Option[int]) -> int:
-        ...     if is_some(opt):
-        ...         return opt.unwrap()  # Type checker knows opt is Some[int]
-        ...     return 0
+        ```python
+        from unwrappy import Option, Some, Nothing, is_some
+
+        def get_value(opt: Option[int]) -> int:
+            if is_some(opt):
+                return opt.unwrap()  # Type checker knows opt is Some[int]
+            return 0
+        ```
     """
     return isinstance(option, Some)
 
@@ -647,10 +653,13 @@ def is_nothing(option: Some[T] | _NothingType) -> TypeIs[_NothingType]:
         True if option is Nothing, with the type narrowed to _NothingType.
 
     Example:
-        >>> from unwrappy import Option, Some, Nothing, is_nothing
-        >>> def describe(opt: Option[int]) -> str:
-        ...     if is_nothing(opt):
-        ...         return "empty"  # Type checker knows opt is Nothing
-        ...     return "has value"
+        ```python
+        from unwrappy import Option, Some, Nothing, is_nothing
+
+        def describe(opt: Option[int]) -> str:
+            if is_nothing(opt):
+                return "empty"  # Type checker knows opt is Nothing
+            return "has value"
+        ```
     """
     return isinstance(option, _NothingType)

--- a/src/unwrappy/option.py
+++ b/src/unwrappy/option.py
@@ -412,9 +412,6 @@ class LazyOption(Generic[T]):
     `.collect()` is called. All methods accept both sync and async
     functions transparently.
 
-    Type Parameters:
-        T: The value type.
-
     Example:
         ```python
         async def fetch_config(key: str) -> Option[str]: ...

--- a/src/unwrappy/result.py
+++ b/src/unwrappy/result.py
@@ -25,11 +25,11 @@ class Ok(Generic[T]):
         value: The success value to wrap.
 
     Example:
-        >>> result = Ok(42)
-        >>> result.unwrap()
-        42
-        >>> result.is_ok()
-        True
+        ```python
+        result = Ok(42)
+        result.unwrap()  # 42
+        result.is_ok()  # True
+        ```
     """
 
     __slots__ = ("_value",)
@@ -189,11 +189,11 @@ class Err(Generic[E]):
         error: The error value to wrap.
 
     Example:
-        >>> result = Err("something went wrong")
-        >>> result.unwrap_err()
-        'something went wrong'
-        >>> result.is_err()
-        True
+        ```python
+        result = Err("something went wrong")
+        result.unwrap_err()  # 'something went wrong'
+        result.is_err()  # True
+        ```
     """
 
     __slots__ = ("_error",)
@@ -420,21 +420,24 @@ class LazyResult(Generic[T, E]):
         E: The error value type.
 
     Example:
-        >>> async def fetch_user(id: int) -> Result[User, str]: ...
-        >>> async def fetch_profile(user: User) -> Result[Profile, str]: ...
-        >>>
-        >>> result = await (
-        ...     LazyResult.from_awaitable(fetch_user(42))
-        ...     .and_then(fetch_profile)   # Async function
-        ...     .map(lambda p: p.name)     # Sync function
-        ...     .tee(print)                # Side effect
-        ...     .collect()
-        ... )
+        ```python
+        async def fetch_user(id: int) -> Result[User, str]: ...
+        async def fetch_profile(user: User) -> Result[Profile, str]: ...
+
+        result = await (
+            LazyResult.from_awaitable(fetch_user(42))
+            .and_then(fetch_profile)   # Async function
+            .map(lambda p: p.name)     # Sync function
+            .tee(print)                # Side effect
+            .collect()
+        )
+        ```
 
     From an existing Result:
-        >>> result = await Ok(5).lazy().map(lambda x: x * 2).collect()
-        >>> result
-        Ok(10)
+        ```python
+        result = await Ok(5).lazy().map(lambda x: x * 2).collect()
+        result  # Ok(10)
+        ```
 
     Note:
         Operations are stored as frozen dataclasses and executed
@@ -570,12 +573,11 @@ def sequence_results(results: Iterable[Ok[T] | Err[E]]) -> Ok[list[T]] | Err[E]:
         Ok(list) if all are Ok, otherwise the first Err.
 
     Example:
-        >>> sequence([Ok(1), Ok(2), Ok(3)])
-        Ok([1, 2, 3])
-        >>> sequence([Ok(1), Err("fail"), Ok(3)])
-        Err('fail')
-        >>> sequence([])
-        Ok([])
+        ```python
+        sequence_results([Ok(1), Ok(2), Ok(3)])  # Ok([1, 2, 3])
+        sequence_results([Ok(1), Err("fail"), Ok(3)])  # Err('fail')
+        sequence_results([])  # Ok([])
+        ```
     """
     values: list[T] = []
     for r in results:
@@ -599,15 +601,16 @@ def traverse_results(items: Iterable[U], fn: Callable[[U], Ok[T] | Err[E]]) -> O
         Ok(list) if all succeed, otherwise the first Err.
 
     Example:
-        >>> def parse_int(s: str) -> Result[int, str]:
-        ...     try:
-        ...         return Ok(int(s))
-        ...     except ValueError:
-        ...         return Err(f"invalid: {s}")
-        >>> traverse_results(["1", "2", "3"], parse_int)
-        Ok([1, 2, 3])
-        >>> traverse_results(["1", "x", "3"], parse_int)
-        Err('invalid: x')
+        ```python
+        def parse_int(s: str) -> Result[int, str]:
+            try:
+                return Ok(int(s))
+            except ValueError:
+                return Err(f"invalid: {s}")
+
+        traverse_results(["1", "2", "3"], parse_int)  # Ok([1, 2, 3])
+        traverse_results(["1", "x", "3"], parse_int)  # Err('invalid: x')
+        ```
     """
     return sequence_results(fn(item) for item in items)
 
@@ -629,11 +632,14 @@ def is_ok(result: Ok[T] | Err[E]) -> TypeIs[Ok[T]]:
         True if result is Ok, with the type narrowed to Ok[T].
 
     Example:
-        >>> from unwrappy import Result, Ok, Err, is_ok
-        >>> def get_value(r: Result[int, str]) -> int:
-        ...     if is_ok(r):
-        ...         return r.unwrap()  # Type checker knows r is Ok[int]
-        ...     return 0
+        ```python
+        from unwrappy import Result, Ok, Err, is_ok
+
+        def get_value(r: Result[int, str]) -> int:
+            if is_ok(r):
+                return r.unwrap()  # Type checker knows r is Ok[int]
+            return 0
+        ```
     """
     return isinstance(result, Ok)
 
@@ -655,10 +661,13 @@ def is_err(result: Ok[T] | Err[E]) -> TypeIs[Err[E]]:
         True if result is Err, with the type narrowed to Err[E].
 
     Example:
-        >>> from unwrappy import Result, Ok, Err, is_err
-        >>> def handle_error(r: Result[int, str]) -> str:
-        ...     if is_err(r):
-        ...         return r.unwrap_err()  # Type checker knows r is Err[str]
-        ...     return "success"
+        ```python
+        from unwrappy import Result, Ok, Err, is_err
+
+        def handle_error(r: Result[int, str]) -> str:
+            if is_err(r):
+                return r.unwrap_err()  # Type checker knows r is Err[str]
+            return "success"
+        ```
     """
     return isinstance(result, Err)

--- a/src/unwrappy/result.py
+++ b/src/unwrappy/result.py
@@ -415,10 +415,6 @@ class LazyResult(Generic[T, E]):
     This pattern is inspired by Polars' lazy evaluation - build the
     computation graph, then execute it all at once.
 
-    Type Parameters:
-        T: The success value type.
-        E: The error value type.
-
     Example:
         ```python
         async def fetch_user(id: int) -> Result[User, str]: ...

--- a/uv.lock
+++ b/uv.lock
@@ -3,12 +3,255 @@ revision = 3
 requires-python = ">=3.10, <4.0"
 
 [[package]]
+name = "babel"
+version = "2.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/e3/bb3a439d5cb255c4774724810ad8073830fac9c9dee123555820c1bcc806/backrefs-6.1.tar.gz", hash = "sha256:3bba1749aafe1db9b915f00e0dd166cba613b6f788ffd63060ac3485dc9be231", size = 7011962, upload-time = "2025-11-15T14:52:08.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ee/c216d52f58ea75b5e1841022bbae24438b19834a29b163cb32aa3a2a7c6e/backrefs-6.1-py310-none-any.whl", hash = "sha256:2a2ccb96302337ce61ee4717ceacfbf26ba4efb1d55af86564b8bbaeda39cac1", size = 381059, upload-time = "2025-11-15T14:51:59.758Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9a/8da246d988ded941da96c7ed945d63e94a445637eaad985a0ed88787cb89/backrefs-6.1-py311-none-any.whl", hash = "sha256:e82bba3875ee4430f4de4b6db19429a27275d95a5f3773c57e9e18abc23fd2b7", size = 392854, upload-time = "2025-11-15T14:52:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c9/fd117a6f9300c62bbc33bc337fd2b3c6bfe28b6e9701de336b52d7a797ad/backrefs-6.1-py312-none-any.whl", hash = "sha256:c64698c8d2269343d88947c0735cb4b78745bd3ba590e10313fbf3f78c34da5a", size = 398770, upload-time = "2025-11-15T14:52:02.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/95/7118e935b0b0bd3f94dfec2d852fd4e4f4f9757bdb49850519acd245cd3a/backrefs-6.1-py313-none-any.whl", hash = "sha256:4c9d3dc1e2e558965202c012304f33d4e0e477e1c103663fd2c3cc9bb18b0d05", size = 400726, upload-time = "2025-11-15T14:52:04.093Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/6296bad135bfafd3254ae3648cd152980a424bd6fed64a101af00cc7ba31/backrefs-6.1-py314-none-any.whl", hash = "sha256:13eafbc9ccd5222e9c1f0bec563e6d2a6d21514962f11e7fc79872fd56cbc853", size = 412584, upload-time = "2025-11-15T14:52:05.233Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e3/a4fa1946722c4c7b063cc25043a12d9ce9b4323777f89643be74cef2993c/backrefs-6.1-py39-none-any.whl", hash = "sha256:a9e99b8a4867852cad177a6430e31b0f6e495d65f8c6c134b68c14c3c95bf4b0", size = 381058, upload-time = "2025-11-15T14:52:06.698Z" },
+]
+
+[[package]]
+name = "cairocffi"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/c5/1a4dc131459e68a173cbdab5fad6b524f53f9c1ef7861b7698e998b837cc/cairocffi-1.7.1.tar.gz", hash = "sha256:2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b", size = 88096, upload-time = "2024-06-18T10:56:06.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d8/ba13451aa6b745c49536e87b6bf8f629b950e84bd0e8308f7dc6883b67e2/cairocffi-1.7.1-py3-none-any.whl", hash = "sha256:9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f", size = 75611, upload-time = "2024-06-18T10:55:59.489Z" },
+]
+
+[[package]]
+name = "cairosvg"
+version = "2.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cairocffi" },
+    { name = "cssselect2" },
+    { name = "defusedxml" },
+    { name = "pillow" },
+    { name = "tinycss2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/b9/5106168bd43d7cd8b7cc2a2ee465b385f14b63f4c092bb89eee2d48c8e67/cairosvg-2.8.2.tar.gz", hash = "sha256:07cbf4e86317b27a92318a4cac2a4bb37a5e9c1b8a27355d06874b22f85bef9f", size = 8398590, upload-time = "2025-05-15T06:56:32.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/48/816bd4aaae93dbf9e408c58598bc32f4a8c65f4b86ab560864cb3ee60adb/cairosvg-2.8.2-py3-none-any.whl", hash = "sha256:eab46dad4674f33267a671dce39b64be245911c901c70d65d2b7b0821e852bf5", size = 45773, upload-time = "2025-05-15T06:56:28.552Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/b8/6d51fc1d52cbd52cd4ccedd5b5b2f0f6a11bbf6765c782298b0f3e808541/charset_normalizer-3.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d", size = 209709, upload-time = "2025-10-14T04:40:11.385Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/af/1f9d7f7faafe2ddfb6f72a2e07a548a629c61ad510fe60f9630309908fef/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8", size = 148814, upload-time = "2025-10-14T04:40:13.135Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3d/f2e3ac2bbc056ca0c204298ea4e3d9db9b4afe437812638759db2c976b5f/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad", size = 144467, upload-time = "2025-10-14T04:40:14.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/85/1bf997003815e60d57de7bd972c57dc6950446a3e4ccac43bc3070721856/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8", size = 162280, upload-time = "2025-10-14T04:40:16.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/8e/6aa1952f56b192f54921c436b87f2aaf7c7a7c3d0d1a765547d64fd83c13/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d", size = 159454, upload-time = "2025-10-14T04:40:17.567Z" },
+    { url = "https://files.pythonhosted.org/packages/36/3b/60cbd1f8e93aa25d1c669c649b7a655b0b5fb4c571858910ea9332678558/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313", size = 153609, upload-time = "2025-10-14T04:40:19.08Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/6a13396948b8fd3c4b4fd5bc74d045f5637d78c9675585e8e9fbe5636554/charset_normalizer-3.4.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e", size = 151849, upload-time = "2025-10-14T04:40:20.607Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7a/59482e28b9981d105691e968c544cc0df3b7d6133152fb3dcdc8f135da7a/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93", size = 151586, upload-time = "2025-10-14T04:40:21.719Z" },
+    { url = "https://files.pythonhosted.org/packages/92/59/f64ef6a1c4bdd2baf892b04cd78792ed8684fbc48d4c2afe467d96b4df57/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0", size = 145290, upload-time = "2025-10-14T04:40:23.069Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/63/3bf9f279ddfa641ffa1962b0db6a57a9c294361cc2f5fcac997049a00e9c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84", size = 163663, upload-time = "2025-10-14T04:40:24.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/09/c9e38fc8fa9e0849b172b581fd9803bdf6e694041127933934184e19f8c3/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e", size = 151964, upload-time = "2025-10-14T04:40:25.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d1/d28b747e512d0da79d8b6a1ac18b7ab2ecfd81b2944c4c710e166d8dd09c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db", size = 161064, upload-time = "2025-10-14T04:40:26.806Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/9a/31d62b611d901c3b9e5500c36aab0ff5eb442043fb3a1c254200d3d397d9/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6", size = 155015, upload-time = "2025-10-14T04:40:28.284Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/107e008fa2bff0c8b9319584174418e5e5285fef32f79d8ee6a430d0039c/charset_normalizer-3.4.4-cp310-cp310-win32.whl", hash = "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f", size = 99792, upload-time = "2025-10-14T04:40:29.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/66/e396e8a408843337d7315bab30dbf106c38966f1819f123257f5520f8a96/charset_normalizer-3.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d", size = 107198, upload-time = "2025-10-14T04:40:30.644Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/58/01b4f815bf0312704c267f2ccb6e5d42bcc7752340cd487bc9f8c3710597/charset_normalizer-3.4.4-cp310-cp310-win_arm64.whl", hash = "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69", size = 100262, upload-time = "2025-10-14T04:40:32.108Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", size = 206988, upload-time = "2025-10-14T04:40:33.79Z" },
+    { url = "https://files.pythonhosted.org/packages/94/59/2e87300fe67ab820b5428580a53cad894272dbb97f38a7a814a2a1ac1011/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0", size = 147324, upload-time = "2025-10-14T04:40:34.961Z" },
+    { url = "https://files.pythonhosted.org/packages/07/fb/0cf61dc84b2b088391830f6274cb57c82e4da8bbc2efeac8c025edb88772/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3", size = 142742, upload-time = "2025-10-14T04:40:36.105Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8b/171935adf2312cd745d290ed93cf16cf0dfe320863ab7cbeeae1dcd6535f/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc", size = 160863, upload-time = "2025-10-14T04:40:37.188Z" },
+    { url = "https://files.pythonhosted.org/packages/09/73/ad875b192bda14f2173bfc1bc9a55e009808484a4b256748d931b6948442/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897", size = 157837, upload-time = "2025-10-14T04:40:38.435Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/fc/de9cce525b2c5b94b47c70a4b4fb19f871b24995c728e957ee68ab1671ea/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381", size = 151550, upload-time = "2025-10-14T04:40:40.053Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c2/43edd615fdfba8c6f2dfbd459b25a6b3b551f24ea21981e23fb768503ce1/charset_normalizer-3.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815", size = 149162, upload-time = "2025-10-14T04:40:41.163Z" },
+    { url = "https://files.pythonhosted.org/packages/03/86/bde4ad8b4d0e9429a4e82c1e8f5c659993a9a863ad62c7df05cf7b678d75/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0", size = 150019, upload-time = "2025-10-14T04:40:42.276Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/86/a151eb2af293a7e7bac3a739b81072585ce36ccfb4493039f49f1d3cae8c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161", size = 143310, upload-time = "2025-10-14T04:40:43.439Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/fe/43dae6144a7e07b87478fdfc4dbe9efd5defb0e7ec29f5f58a55aeef7bf7/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4", size = 162022, upload-time = "2025-10-14T04:40:44.547Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e6/7aab83774f5d2bca81f42ac58d04caf44f0cc2b65fc6db2b3b2e8a05f3b3/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89", size = 149383, upload-time = "2025-10-14T04:40:46.018Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e8/b289173b4edae05c0dde07f69f8db476a0b511eac556dfe0d6bda3c43384/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569", size = 159098, upload-time = "2025-10-14T04:40:47.081Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/df/fe699727754cae3f8478493c7f45f777b17c3ef0600e28abfec8619eb49c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224", size = 152991, upload-time = "2025-10-14T04:40:48.246Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/86/584869fe4ddb6ffa3bd9f491b87a01568797fb9bd8933f557dba9771beaf/charset_normalizer-3.4.4-cp311-cp311-win32.whl", hash = "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a", size = 99456, upload-time = "2025-10-14T04:40:49.376Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f6/62fdd5feb60530f50f7e38b4f6a1d5203f4d16ff4f9f0952962c044e919a/charset_normalizer-3.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016", size = 106978, upload-time = "2025-10-14T04:40:50.844Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/9d/0710916e6c82948b3be62d9d398cb4fcf4e97b56d6a6aeccd66c4b2f2bd5/charset_normalizer-3.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1", size = 99969, upload-time = "2025-10-14T04:40:52.272Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
+    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
+    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
+    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
+    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -125,6 +368,28 @@ toml = [
 ]
 
 [[package]]
+name = "cssselect2"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/86/fd7f58fc498b3166f3a7e8e0cddb6e620fe1da35b02248b1bd59e95dbaaa/cssselect2-0.8.0.tar.gz", hash = "sha256:7674ffb954a3b46162392aee2a3a0aedb2e14ecf99fcc28644900f4e6e3e9d3a", size = 35716, upload-time = "2025-03-05T14:46:07.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/e7/aa315e6a749d9b96c2504a1ba0ba031ba2d0517e972ce22682e3fccecb09/cssselect2-0.8.0-py3-none-any.whl", hash = "sha256:46fc70ebc41ced7a32cd42d58b1884d72ade23d21e5a4eaaf022401c13f0e76e", size = 15454, upload-time = "2025-03-05T14:46:06.463Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -137,12 +402,57 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -219,6 +529,229 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/7dd27d9d863b3376fcf23a5a13cb5d024aed1db46f963f1b5735ae43b3be/markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e", size = 364931, upload-time = "2025-11-03T19:51:15.007Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c", size = 107678, upload-time = "2025-11-03T19:51:13.887Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/fa/9124cd63d822e2bcbea1450ae68cdc3faf3655c69b455f3a7ed36ce6c628/mkdocs_autorefs-1.4.3.tar.gz", hash = "sha256:beee715b254455c4aa93b6ef3c67579c399ca092259cc41b7d9342573ff1fc75", size = 55425, upload-time = "2025-08-26T14:23:17.223Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/4d/7123b6fa2278000688ebd338e2a06d16870aaf9eceae6ba047ea05f92df1/mkdocs_autorefs-1.4.3-py3-none-any.whl", hash = "sha256:469d85eb3114801d08e9cc55d102b3ba65917a869b893403b8987b601cf55dc9", size = 25034, upload-time = "2025-08-26T14:23:15.906Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/e2/2ffc356cd72f1473d07c7719d82a8f2cbd261666828614ecb95b12169f41/mkdocs_material-9.7.1.tar.gz", hash = "sha256:89601b8f2c3e6c6ee0a918cc3566cb201d40bf37c3cd3c2067e26fadb8cce2b8", size = 4094392, upload-time = "2025-12-18T09:49:00.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/32/ed071cb721aca8c227718cffcf7bd539620e9799bbf2619e90c757bfd030/mkdocs_material-9.7.1-py3-none-any.whl", hash = "sha256:3f6100937d7d731f87f1e3e3b021c97f7239666b9ba1151ab476cabb96c60d5c", size = 9297166, upload-time = "2025-12-18T09:48:56.664Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/13/10bbf9d56565fd91b91e6f5a8cd9b9d8a2b101c4e8ad6eeafa35a706301d/mkdocstrings-1.0.0.tar.gz", hash = "sha256:351a006dbb27aefce241ade110d3cd040c1145b7a3eb5fd5ac23f03ed67f401a", size = 101086, upload-time = "2025-11-27T15:39:40.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/fc/80aa31b79133634721cf7855d37b76ea49773599214896f2ff10be03de2a/mkdocstrings-1.0.0-py3-none-any.whl", hash = "sha256:4c50eb960bff6e05dfc631f6bc00dfabffbcb29c5ff25f676d64daae05ed82fa", size = 35135, upload-time = "2025-11-27T15:39:39.301Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffe" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/75/d30af27a2906f00eb90143470272376d728521997800f5dce5b340ba35bc/mkdocstrings_python-2.0.1.tar.gz", hash = "sha256:843a562221e6a471fefdd4b45cc6c22d2607ccbad632879234fa9692e9cf7732", size = 199345, upload-time = "2025-12-03T14:26:11.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/06/c5f8deba7d2cbdfa7967a716ae801aa9ca5f734b8f54fd473ef77a088dbe/mkdocstrings_python-2.0.1-py3-none-any.whl", hash = "sha256:66ecff45c5f8b71bf174e11d49afc845c2dfc7fc0ab17a86b6b337e0f24d8d90", size = 105055, upload-time = "2025-12-03T14:26:10.184Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -292,12 +825,128 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/b2/bb8e495d5262bfec41ab5cb18f522f1012933347fb5d9e62452d446baca2/pathspec-1.0.3.tar.gz", hash = "sha256:bac5cf97ae2c2876e2d25ebb15078eb04d76e4b98921ee31c6f85ade8b59444d", size = 130841, upload-time = "2026-01-09T15:46:46.009Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/2b/121e912bd60eebd623f873fd090de0e84f322972ab25a7f9044c056804ed/pathspec-1.0.3-py3-none-any.whl", hash = "sha256:e80767021c1cc524aa3fb14bedda9c34406591343cc42797b386ce7b9354fb6c", size = 55021, upload-time = "2026-01-09T15:46:44.652Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/02/d52c733a2452ef1ffcc123b68e6606d07276b0e358db70eabad7e40042b7/pillow-12.1.0.tar.gz", hash = "sha256:5c5ae0a06e9ea030ab786b0251b32c7e4ce10e58d983c0d5c56029455180b5b9", size = 46977283, upload-time = "2026-01-02T09:13:29.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/41/f73d92b6b883a579e79600d391f2e21cb0df767b2714ecbd2952315dfeef/pillow-12.1.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:fb125d860738a09d363a88daa0f59c4533529a90e564785e20fe875b200b6dbd", size = 5304089, upload-time = "2026-01-02T09:10:24.953Z" },
+    { url = "https://files.pythonhosted.org/packages/94/55/7aca2891560188656e4a91ed9adba305e914a4496800da6b5c0a15f09edf/pillow-12.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cad302dc10fac357d3467a74a9561c90609768a6f73a1923b0fd851b6486f8b0", size = 4657815, upload-time = "2026-01-02T09:10:27.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d2/b28221abaa7b4c40b7dba948f0f6a708bd7342c4d47ce342f0ea39643974/pillow-12.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a40905599d8079e09f25027423aed94f2823adaf2868940de991e53a449e14a8", size = 6222593, upload-time = "2026-01-02T09:10:29.115Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b8/7a61fb234df6a9b0b479f69e66901209d89ff72a435b49933f9122f94cac/pillow-12.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:92a7fe4225365c5e3a8e598982269c6d6698d3e783b3b1ae979e7819f9cd55c1", size = 8027579, upload-time = "2026-01-02T09:10:31.182Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/51/55c751a57cc524a15a0e3db20e5cde517582359508d62305a627e77fd295/pillow-12.1.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f10c98f49227ed8383d28174ee95155a675c4ed7f85e2e573b04414f7e371bda", size = 6335760, upload-time = "2026-01-02T09:10:33.02Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7c/60e3e6f5e5891a1a06b4c910f742ac862377a6fe842f7184df4a274ce7bf/pillow-12.1.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8637e29d13f478bc4f153d8daa9ffb16455f0a6cb287da1b432fdad2bfbd66c7", size = 7027127, upload-time = "2026-01-02T09:10:35.009Z" },
+    { url = "https://files.pythonhosted.org/packages/06/37/49d47266ba50b00c27ba63a7c898f1bb41a29627ced8c09e25f19ebec0ff/pillow-12.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:21e686a21078b0f9cb8c8a961d99e6a4ddb88e0fc5ea6e130172ddddc2e5221a", size = 6449896, upload-time = "2026-01-02T09:10:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/67fd87d2913902462cd9b79c6211c25bfe95fcf5783d06e1367d6d9a741f/pillow-12.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2415373395a831f53933c23ce051021e79c8cd7979822d8cc478547a3f4da8ef", size = 7151345, upload-time = "2026-01-02T09:10:39.064Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/15/f8c7abf82af68b29f50d77c227e7a1f87ce02fdc66ded9bf603bc3b41180/pillow-12.1.0-cp310-cp310-win32.whl", hash = "sha256:e75d3dba8fc1ddfec0cd752108f93b83b4f8d6ab40e524a95d35f016b9683b09", size = 6325568, upload-time = "2026-01-02T09:10:41.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/7d1c0e160b6b5ac2605ef7d8be537e28753c0db5363d035948073f5513d7/pillow-12.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:64efdf00c09e31efd754448a383ea241f55a994fd079866b92d2bbff598aad91", size = 7032367, upload-time = "2026-01-02T09:10:43.09Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/03/41c038f0d7a06099254c60f618d0ec7be11e79620fc23b8e85e5b31d9a44/pillow-12.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:f188028b5af6b8fb2e9a76ac0f841a575bd1bd396e46ef0840d9b88a48fdbcea", size = 2452345, upload-time = "2026-01-02T09:10:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c4/bf8328039de6cc22182c3ef007a2abfbbdab153661c0a9aa78af8d706391/pillow-12.1.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:a83e0850cb8f5ac975291ebfc4170ba481f41a28065277f7f735c202cd8e0af3", size = 5304057, upload-time = "2026-01-02T09:10:46.627Z" },
+    { url = "https://files.pythonhosted.org/packages/43/06/7264c0597e676104cc22ca73ee48f752767cd4b1fe084662620b17e10120/pillow-12.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b6e53e82ec2db0717eabb276aa56cf4e500c9a7cec2c2e189b55c24f65a3e8c0", size = 4657811, upload-time = "2026-01-02T09:10:49.548Z" },
+    { url = "https://files.pythonhosted.org/packages/72/64/f9189e44474610daf83da31145fa56710b627b5c4c0b9c235e34058f6b31/pillow-12.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:40a8e3b9e8773876d6e30daed22f016509e3987bab61b3b7fe309d7019a87451", size = 6232243, upload-time = "2026-01-02T09:10:51.62Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/30/0df458009be6a4caca4ca2c52975e6275c387d4e5c95544e34138b41dc86/pillow-12.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:800429ac32c9b72909c671aaf17ecd13110f823ddb7db4dfef412a5587c2c24e", size = 8037872, upload-time = "2026-01-02T09:10:53.446Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/86/95845d4eda4f4f9557e25381d70876aa213560243ac1a6d619c46caaedd9/pillow-12.1.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b022eaaf709541b391ee069f0022ee5b36c709df71986e3f7be312e46f42c84", size = 6345398, upload-time = "2026-01-02T09:10:55.426Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1f/8e66ab9be3aaf1435bc03edd1ebdf58ffcd17f7349c1d970cafe87af27d9/pillow-12.1.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f345e7bc9d7f368887c712aa5054558bad44d2a301ddf9248599f4161abc7c0", size = 7034667, upload-time = "2026-01-02T09:10:57.11Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f6/683b83cb9b1db1fb52b87951b1c0b99bdcfceaa75febf11406c19f82cb5e/pillow-12.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d70347c8a5b7ccd803ec0c85c8709f036e6348f1e6a5bf048ecd9c64d3550b8b", size = 6458743, upload-time = "2026-01-02T09:10:59.331Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/7d/de833d63622538c1d58ce5395e7c6cb7e7dce80decdd8bde4a484e095d9f/pillow-12.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1fcc52d86ce7a34fd17cb04e87cfdb164648a3662a6f20565910a99653d66c18", size = 7159342, upload-time = "2026-01-02T09:11:01.82Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/40/50d86571c9e5868c42b81fe7da0c76ca26373f3b95a8dd675425f4a92ec1/pillow-12.1.0-cp311-cp311-win32.whl", hash = "sha256:3ffaa2f0659e2f740473bcf03c702c39a8d4b2b7ffc629052028764324842c64", size = 6328655, upload-time = "2026-01-02T09:11:04.556Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/af/b1d7e301c4cd26cd45d4af884d9ee9b6fab893b0ad2450d4746d74a6968c/pillow-12.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:806f3987ffe10e867bab0ddad45df1148a2b98221798457fa097ad85d6e8bc75", size = 7031469, upload-time = "2026-01-02T09:11:06.538Z" },
+    { url = "https://files.pythonhosted.org/packages/48/36/d5716586d887fb2a810a4a61518a327a1e21c8b7134c89283af272efe84b/pillow-12.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:9f5fefaca968e700ad1a4a9de98bf0869a94e397fe3524c4c9450c1445252304", size = 2452515, upload-time = "2026-01-02T09:11:08.226Z" },
+    { url = "https://files.pythonhosted.org/packages/20/31/dc53fe21a2f2996e1b7d92bf671cdb157079385183ef7c1ae08b485db510/pillow-12.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a332ac4ccb84b6dde65dbace8431f3af08874bf9770719d32a635c4ef411b18b", size = 5262642, upload-time = "2026-01-02T09:11:10.138Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c1/10e45ac9cc79419cedf5121b42dcca5a50ad2b601fa080f58c22fb27626e/pillow-12.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:907bfa8a9cb790748a9aa4513e37c88c59660da3bcfffbd24a7d9e6abf224551", size = 4657464, upload-time = "2026-01-02T09:11:12.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/26/7b82c0ab7ef40ebede7a97c72d473bda5950f609f8e0c77b04af574a0ddb/pillow-12.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:efdc140e7b63b8f739d09a99033aa430accce485ff78e6d311973a67b6bf3208", size = 6234878, upload-time = "2026-01-02T09:11:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/76/25/27abc9792615b5e886ca9411ba6637b675f1b77af3104710ac7353fe5605/pillow-12.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bef9768cab184e7ae6e559c032e95ba8d07b3023c289f79a2bd36e8bf85605a5", size = 8044868, upload-time = "2026-01-02T09:11:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ea/f200a4c36d836100e7bc738fc48cd963d3ba6372ebc8298a889e0cfc3359/pillow-12.1.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:742aea052cf5ab5034a53c3846165bc3ce88d7c38e954120db0ab867ca242661", size = 6349468, upload-time = "2026-01-02T09:11:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8f/48d0b77ab2200374c66d344459b8958c86693be99526450e7aee714e03e4/pillow-12.1.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6dfc2af5b082b635af6e08e0d1f9f1c4e04d17d4e2ca0ef96131e85eda6eb17", size = 7041518, upload-time = "2026-01-02T09:11:19.389Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/23/c281182eb986b5d31f0a76d2a2c8cd41722d6fb8ed07521e802f9bba52de/pillow-12.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:609e89d9f90b581c8d16358c9087df76024cf058fa693dd3e1e1620823f39670", size = 6462829, upload-time = "2026-01-02T09:11:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ef/7018273e0faac099d7b00982abdcc39142ae6f3bd9ceb06de09779c4a9d6/pillow-12.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:43b4899cfd091a9693a1278c4982f3e50f7fb7cff5153b05174b4afc9593b616", size = 7166756, upload-time = "2026-01-02T09:11:23.559Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/c8/993d4b7ab2e341fe02ceef9576afcf5830cdec640be2ac5bee1820d693d4/pillow-12.1.0-cp312-cp312-win32.whl", hash = "sha256:aa0c9cc0b82b14766a99fbe6084409972266e82f459821cd26997a488a7261a7", size = 6328770, upload-time = "2026-01-02T09:11:25.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/87/90b358775a3f02765d87655237229ba64a997b87efa8ccaca7dd3e36e7a7/pillow-12.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:d70534cea9e7966169ad29a903b99fc507e932069a881d0965a1a84bb57f6c6d", size = 7033406, upload-time = "2026-01-02T09:11:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/cf/881b457eccacac9e5b2ddd97d5071fb6d668307c57cbf4e3b5278e06e536/pillow-12.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:65b80c1ee7e14a87d6a068dd3b0aea268ffcabfe0498d38661b00c5b4b22e74c", size = 2452612, upload-time = "2026-01-02T09:11:29.309Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c7/2530a4aa28248623e9d7f27316b42e27c32ec410f695929696f2e0e4a778/pillow-12.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7b5dd7cbae20285cdb597b10eb5a2c13aa9de6cde9bb64a3c1317427b1db1ae1", size = 4062543, upload-time = "2026-01-02T09:11:31.566Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1f/40b8eae823dc1519b87d53c30ed9ef085506b05281d313031755c1705f73/pillow-12.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:29a4cef9cb672363926f0470afc516dbf7305a14d8c54f7abbb5c199cd8f8179", size = 4138373, upload-time = "2026-01-02T09:11:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/77/6fa60634cf06e52139fd0e89e5bbf055e8166c691c42fb162818b7fda31d/pillow-12.1.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:681088909d7e8fa9e31b9799aaa59ba5234c58e5e4f1951b4c4d1082a2e980e0", size = 3601241, upload-time = "2026-01-02T09:11:35.011Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/bf/28ab865de622e14b747f0cd7877510848252d950e43002e224fb1c9ababf/pillow-12.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:983976c2ab753166dc66d36af6e8ec15bb511e4a25856e2227e5f7e00a160587", size = 5262410, upload-time = "2026-01-02T09:11:36.682Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/34/583420a1b55e715937a85bd48c5c0991598247a1fd2eb5423188e765ea02/pillow-12.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:db44d5c160a90df2d24a24760bbd37607d53da0b34fb546c4c232af7192298ac", size = 4657312, upload-time = "2026-01-02T09:11:38.535Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/fd/f5a0896839762885b3376ff04878f86ab2b097c2f9a9cdccf4eda8ba8dc0/pillow-12.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6b7a9d1db5dad90e2991645874f708e87d9a3c370c243c2d7684d28f7e133e6b", size = 6232605, upload-time = "2026-01-02T09:11:40.602Z" },
+    { url = "https://files.pythonhosted.org/packages/98/aa/938a09d127ac1e70e6ed467bd03834350b33ef646b31edb7452d5de43792/pillow-12.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6258f3260986990ba2fa8a874f8b6e808cf5abb51a94015ca3dc3c68aa4f30ea", size = 8041617, upload-time = "2026-01-02T09:11:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e8/538b24cb426ac0186e03f80f78bc8dc7246c667f58b540bdd57c71c9f79d/pillow-12.1.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e115c15e3bc727b1ca3e641a909f77f8ca72a64fff150f666fcc85e57701c26c", size = 6346509, upload-time = "2026-01-02T09:11:44.955Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/632e58ec89a32738cabfd9ec418f0e9898a2b4719afc581f07c04a05e3c9/pillow-12.1.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6741e6f3074a35e47c77b23a4e4f2d90db3ed905cb1c5e6e0d49bff2045632bc", size = 7038117, upload-time = "2026-01-02T09:11:46.736Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a2/d40308cf86eada842ca1f3ffa45d0ca0df7e4ab33c83f81e73f5eaed136d/pillow-12.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:935b9d1aed48fcfb3f838caac506f38e29621b44ccc4f8a64d575cb1b2a88644", size = 6460151, upload-time = "2026-01-02T09:11:48.625Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/88/f5b058ad6453a085c5266660a1417bdad590199da1b32fb4efcff9d33b05/pillow-12.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5fee4c04aad8932da9f8f710af2c1a15a83582cfb884152a9caa79d4efcdbf9c", size = 7164534, upload-time = "2026-01-02T09:11:50.445Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ce/c17334caea1db789163b5d855a5735e47995b0b5dc8745e9a3605d5f24c0/pillow-12.1.0-cp313-cp313-win32.whl", hash = "sha256:a786bf667724d84aa29b5db1c61b7bfdde380202aaca12c3461afd6b71743171", size = 6332551, upload-time = "2026-01-02T09:11:52.234Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/07/74a9d941fa45c90a0d9465098fe1ec85de3e2afbdc15cc4766622d516056/pillow-12.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:461f9dfdafa394c59cd6d818bdfdbab4028b83b02caadaff0ffd433faf4c9a7a", size = 7040087, upload-time = "2026-01-02T09:11:54.822Z" },
+    { url = "https://files.pythonhosted.org/packages/88/09/c99950c075a0e9053d8e880595926302575bc742b1b47fe1bbcc8d388d50/pillow-12.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:9212d6b86917a2300669511ed094a9406888362e085f2431a7da985a6b124f45", size = 2452470, upload-time = "2026-01-02T09:11:56.522Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/ba/970b7d85ba01f348dee4d65412476321d40ee04dcb51cd3735b9dc94eb58/pillow-12.1.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:00162e9ca6d22b7c3ee8e61faa3c3253cd19b6a37f126cad04f2f88b306f557d", size = 5264816, upload-time = "2026-01-02T09:11:58.227Z" },
+    { url = "https://files.pythonhosted.org/packages/10/60/650f2fb55fdba7a510d836202aa52f0baac633e50ab1cf18415d332188fb/pillow-12.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7d6daa89a00b58c37cb1747ec9fb7ac3bc5ffd5949f5888657dfddde6d1312e0", size = 4660472, upload-time = "2026-01-02T09:12:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/5273a99478956a099d533c4f46cbaa19fd69d606624f4334b85e50987a08/pillow-12.1.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2479c7f02f9d505682dc47df8c0ea1fc5e264c4d1629a5d63fe3e2334b89554", size = 6268974, upload-time = "2026-01-02T09:12:02.572Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/26/0bf714bc2e73d5267887d47931d53c4ceeceea6978148ed2ab2a4e6463c4/pillow-12.1.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f188d580bd870cda1e15183790d1cc2fa78f666e76077d103edf048eed9c356e", size = 8073070, upload-time = "2026-01-02T09:12:04.75Z" },
+    { url = "https://files.pythonhosted.org/packages/43/cf/1ea826200de111a9d65724c54f927f3111dc5ae297f294b370a670c17786/pillow-12.1.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0fde7ec5538ab5095cc02df38ee99b0443ff0e1c847a045554cf5f9af1f4aa82", size = 6380176, upload-time = "2026-01-02T09:12:06.626Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e0/7938dd2b2013373fd85d96e0f38d62b7a5a262af21ac274250c7ca7847c9/pillow-12.1.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ed07dca4a8464bada6139ab38f5382f83e5f111698caf3191cb8dbf27d908b4", size = 7067061, upload-time = "2026-01-02T09:12:08.624Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ad/a2aa97d37272a929a98437a8c0ac37b3cf012f4f8721e1bd5154699b2518/pillow-12.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f45bd71d1fa5e5749587613037b172e0b3b23159d1c00ef2fc920da6f470e6f0", size = 6491824, upload-time = "2026-01-02T09:12:10.488Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/44/80e46611b288d51b115826f136fb3465653c28f491068a72d3da49b54cd4/pillow-12.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:277518bf4fe74aa91489e1b20577473b19ee70fb97c374aa50830b279f25841b", size = 7190911, upload-time = "2026-01-02T09:12:12.772Z" },
+    { url = "https://files.pythonhosted.org/packages/86/77/eacc62356b4cf81abe99ff9dbc7402750044aed02cfd6a503f7c6fc11f3e/pillow-12.1.0-cp313-cp313t-win32.whl", hash = "sha256:7315f9137087c4e0ee73a761b163fc9aa3b19f5f606a7fc08d83fd3e4379af65", size = 6336445, upload-time = "2026-01-02T09:12:14.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3c/57d81d0b74d218706dafccb87a87ea44262c43eef98eb3b164fd000e0491/pillow-12.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:0ddedfaa8b5f0b4ffbc2fa87b556dc59f6bb4ecb14a53b33f9189713ae8053c0", size = 7045354, upload-time = "2026-01-02T09:12:16.599Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/82/8b9b97bba2e3576a340f93b044a3a3a09841170ab4c1eb0d5c93469fd32f/pillow-12.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:80941e6d573197a0c28f394753de529bb436b1ca990ed6e765cf42426abc39f8", size = 2454547, upload-time = "2026-01-02T09:12:18.704Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/87/bdf971d8bbcf80a348cc3bacfcb239f5882100fe80534b0ce67a784181d8/pillow-12.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:5cb7bc1966d031aec37ddb9dcf15c2da5b2e9f7cc3ca7c54473a20a927e1eb91", size = 4062533, upload-time = "2026-01-02T09:12:20.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4f/5eb37a681c68d605eb7034c004875c81f86ec9ef51f5be4a63eadd58859a/pillow-12.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:97e9993d5ed946aba26baf9c1e8cf18adbab584b99f452ee72f7ee8acb882796", size = 4138546, upload-time = "2026-01-02T09:12:23.664Z" },
+    { url = "https://files.pythonhosted.org/packages/11/6d/19a95acb2edbace40dcd582d077b991646b7083c41b98da4ed7555b59733/pillow-12.1.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:414b9a78e14ffeb98128863314e62c3f24b8a86081066625700b7985b3f529bd", size = 3601163, upload-time = "2026-01-02T09:12:26.338Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/36/2b8138e51cb42e4cc39c3297713455548be855a50558c3ac2beebdc251dd/pillow-12.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e6bdb408f7c9dd2a5ff2b14a3b0bb6d4deb29fb9961e6eb3ae2031ae9a5cec13", size = 5266086, upload-time = "2026-01-02T09:12:28.782Z" },
+    { url = "https://files.pythonhosted.org/packages/53/4b/649056e4d22e1caa90816bf99cef0884aed607ed38075bd75f091a607a38/pillow-12.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3413c2ae377550f5487991d444428f1a8ae92784aac79caa8b1e3b89b175f77e", size = 4657344, upload-time = "2026-01-02T09:12:31.117Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6b/c5742cea0f1ade0cd61485dc3d81f05261fc2276f537fbdc00802de56779/pillow-12.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e5dcbe95016e88437ecf33544ba5db21ef1b8dd6e1b434a2cb2a3d605299e643", size = 6232114, upload-time = "2026-01-02T09:12:32.936Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/8f/9f521268ce22d63991601aafd3d48d5ff7280a246a1ef62d626d67b44064/pillow-12.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d0a7735df32ccbcc98b98a1ac785cc4b19b580be1bdf0aeb5c03223220ea09d5", size = 8042708, upload-time = "2026-01-02T09:12:34.78Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/eb/257f38542893f021502a1bbe0c2e883c90b5cff26cc33b1584a841a06d30/pillow-12.1.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c27407a2d1b96774cbc4a7594129cc027339fd800cd081e44497722ea1179de", size = 6347762, upload-time = "2026-01-02T09:12:36.748Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5a/8ba375025701c09b309e8d5163c5a4ce0102fa86bbf8800eb0d7ac87bc51/pillow-12.1.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15c794d74303828eaa957ff8070846d0efe8c630901a1c753fdc63850e19ecd9", size = 7039265, upload-time = "2026-01-02T09:12:39.082Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/dc/cf5e4cdb3db533f539e88a7bbf9f190c64ab8a08a9bc7a4ccf55067872e4/pillow-12.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c990547452ee2800d8506c4150280757f88532f3de2a58e3022e9b179107862a", size = 6462341, upload-time = "2026-01-02T09:12:40.946Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/47/0291a25ac9550677e22eda48510cfc4fa4b2ef0396448b7fbdc0a6946309/pillow-12.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b63e13dd27da389ed9475b3d28510f0f954bca0041e8e551b2a4eb1eab56a39a", size = 7165395, upload-time = "2026-01-02T09:12:42.706Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4c/e005a59393ec4d9416be06e6b45820403bb946a778e39ecec62f5b2b991e/pillow-12.1.0-cp314-cp314-win32.whl", hash = "sha256:1a949604f73eb07a8adab38c4fe50791f9919344398bdc8ac6b307f755fc7030", size = 6431413, upload-time = "2026-01-02T09:12:44.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/af/f23697f587ac5f9095d67e31b81c95c0249cd461a9798a061ed6709b09b5/pillow-12.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f9f6a650743f0ddee5593ac9e954ba1bdbc5e150bc066586d4f26127853ab94", size = 7176779, upload-time = "2026-01-02T09:12:46.727Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/36/6a51abf8599232f3e9afbd16d52829376a68909fe14efe29084445db4b73/pillow-12.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:808b99604f7873c800c4840f55ff389936ef1948e4e87645eaf3fccbc8477ac4", size = 2543105, upload-time = "2026-01-02T09:12:49.243Z" },
+    { url = "https://files.pythonhosted.org/packages/82/54/2e1dd20c8749ff225080d6ba465a0cab4387f5db0d1c5fb1439e2d99923f/pillow-12.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc11908616c8a283cf7d664f77411a5ed2a02009b0097ff8abbba5e79128ccf2", size = 5268571, upload-time = "2026-01-02T09:12:51.11Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/571163a5ef86ec0cf30d265ac2a70ae6fc9e28413d1dc94fa37fae6bda89/pillow-12.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:896866d2d436563fa2a43a9d72f417874f16b5545955c54a64941e87c1376c61", size = 4660426, upload-time = "2026-01-02T09:12:52.865Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e1/53ee5163f794aef1bf84243f755ee6897a92c708505350dd1923f4afec48/pillow-12.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8e178e3e99d3c0ea8fc64b88447f7cac8ccf058af422a6cedc690d0eadd98c51", size = 6269908, upload-time = "2026-01-02T09:12:54.884Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/0b/b4b4106ff0ee1afa1dc599fde6ab230417f800279745124f6c50bcffed8e/pillow-12.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:079af2fb0c599c2ec144ba2c02766d1b55498e373b3ac64687e43849fbbef5bc", size = 8074733, upload-time = "2026-01-02T09:12:56.802Z" },
+    { url = "https://files.pythonhosted.org/packages/19/9f/80b411cbac4a732439e629a26ad3ef11907a8c7fc5377b7602f04f6fe4e7/pillow-12.1.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bdec5e43377761c5dbca620efb69a77f6855c5a379e32ac5b158f54c84212b14", size = 6381431, upload-time = "2026-01-02T09:12:58.823Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b7/d65c45db463b66ecb6abc17c6ba6917a911202a07662247e1355ce1789e7/pillow-12.1.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:565c986f4b45c020f5421a4cea13ef294dde9509a8577f29b2fc5edc7587fff8", size = 7068529, upload-time = "2026-01-02T09:13:00.885Z" },
+    { url = "https://files.pythonhosted.org/packages/50/96/dfd4cd726b4a45ae6e3c669fc9e49deb2241312605d33aba50499e9d9bd1/pillow-12.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:43aca0a55ce1eefc0aefa6253661cb54571857b1a7b2964bd8a1e3ef4b729924", size = 6492981, upload-time = "2026-01-02T09:13:03.314Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/1c/b5dc52cf713ae46033359c5ca920444f18a6359ce1020dd3e9c553ea5bc6/pillow-12.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0deedf2ea233722476b3a81e8cdfbad786f7adbed5d848469fa59fe52396e4ef", size = 7191878, upload-time = "2026-01-02T09:13:05.276Z" },
+    { url = "https://files.pythonhosted.org/packages/53/26/c4188248bd5edaf543864fe4834aebe9c9cb4968b6f573ce014cc42d0720/pillow-12.1.0-cp314-cp314t-win32.whl", hash = "sha256:b17fbdbe01c196e7e159aacb889e091f28e61020a8abeac07b68079b6e626988", size = 6438703, upload-time = "2026-01-02T09:13:07.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0e/69ed296de8ea05cb03ee139cee600f424ca166e632567b2d66727f08c7ed/pillow-12.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27b9baecb428899db6c0de572d6d305cfaf38ca1596b5c0542a5182e3e74e8c6", size = 7182927, upload-time = "2026-01-02T09:13:09.841Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f5/68334c015eed9b5cff77814258717dec591ded209ab5b6fb70e2ae873d1d/pillow-12.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f61333d817698bdcdd0f9d7793e365ac3d2a21c1f1eb02b32ad6aefb8d8ea831", size = 2545104, upload-time = "2026-01-02T09:13:12.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/bc/224b1d98cffd7164b14707c91aac83c07b047fbd8f58eba4066a3e53746a/pillow-12.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ca94b6aac0d7af2a10ba08c0f888b3d5114439b6b3ef39968378723622fed377", size = 5228605, upload-time = "2026-01-02T09:13:14.084Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ca/49ca7769c4550107de049ed85208240ba0f330b3f2e316f24534795702ce/pillow-12.1.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:351889afef0f485b84078ea40fe33727a0492b9af3904661b0abbafee0355b72", size = 4622245, upload-time = "2026-01-02T09:13:15.964Z" },
+    { url = "https://files.pythonhosted.org/packages/73/48/fac807ce82e5955bcc2718642b94b1bd22a82a6d452aea31cbb678cddf12/pillow-12.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bb0984b30e973f7e2884362b7d23d0a348c7143ee559f38ef3eaab640144204c", size = 5247593, upload-time = "2026-01-02T09:13:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/95/3e0742fe358c4664aed4fd05d5f5373dcdad0b27af52aa0972568541e3f4/pillow-12.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:84cabc7095dd535ca934d57e9ce2a72ffd216e435a84acb06b2277b1de2689bd", size = 6989008, upload-time = "2026-01-02T09:13:20.083Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/74/fe2ac378e4e202e56d50540d92e1ef4ff34ed687f3c60f6a121bcf99437e/pillow-12.1.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53d8b764726d3af1a138dd353116f774e3862ec7e3794e0c8781e30db0f35dfc", size = 5313824, upload-time = "2026-01-02T09:13:22.405Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/77/2a60dee1adee4e2655ac328dd05c02a955c1cd683b9f1b82ec3feb44727c/pillow-12.1.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5da841d81b1a05ef940a8567da92decaa15bc4d7dedb540a8c219ad83d91808a", size = 5963278, upload-time = "2026-01-02T09:13:24.706Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/71/64e9b1c7f04ae0027f788a248e6297d7fcc29571371fe7d45495a78172c0/pillow-12.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:75af0b4c229ac519b155028fa1be632d812a519abba9b46b20e50c6caa184f19", size = 7029809, upload-time = "2026-01-02T09:13:26.541Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
 ]
 
 [[package]]
@@ -310,12 +959,34 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/35/e3814a5b7df295df69d035cfb8aab78b2967cdf11fcfae7faed726b66664/pymdown_extensions-10.20.tar.gz", hash = "sha256:5c73566ab0cf38c6ba084cb7c5ea64a119ae0500cce754ccb682761dfea13a52", size = 852774, upload-time = "2025-12-31T19:59:42.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/10/47caf89cbb52e5bb764696fd52a8c591a2f0e851a93270c05a17f36000b5/pymdown_extensions-10.20-py3-none-any.whl", hash = "sha256:ea9e62add865da80a271d00bfa1c0fa085b20d133fb3fc97afdc88e682f60b2f", size = 268733, upload-time = "2025-12-31T19:59:40.652Z" },
 ]
 
 [[package]]
@@ -378,6 +1049,109 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.11"
 source = { registry = "https://pypi.org/simple" }
@@ -401,6 +1175,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/02/bb3ff8b6e6d02ce9e3740f4c17dfbbfb55f34c789c139e9cd91985f356c7/ruff-0.14.11-py3-none-win32.whl", hash = "sha256:337c5dd11f16ee52ae217757d9b82a26400be7efac883e9e852646f1557ed841", size = 12851094, upload-time = "2026-01-08T19:11:45.163Z" },
     { url = "https://files.pythonhosted.org/packages/58/f1/90ddc533918d3a2ad628bc3044cdfc094949e6d4b929220c3f0eb8a1c998/ruff-0.14.11-py3-none-win_amd64.whl", hash = "sha256:f981cea63d08456b2c070e64b79cb62f951aa1305282974d4d5216e6e0178ae6", size = 14001379, upload-time = "2026-01-08T19:11:52.591Z" },
     { url = "https://files.pythonhosted.org/packages/c4/1c/1dbe51782c0e1e9cfce1d1004752672d2d4629ea46945d19d731ad772b3b/ruff-0.14.11-py3-none-win_arm64.whl", hash = "sha256:649fb6c9edd7f751db276ef42df1f3df41c38d67d199570ae2a7bd6cbc3590f0", size = 12938644, upload-time = "2026-01-08T19:11:50.027Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
 ]
 
 [[package]]
@@ -507,6 +1302,12 @@ dev = [
     { name = "ty" },
     { name = "typing-extensions" },
 ]
+docs = [
+    { name = "cairosvg" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+    { name = "pillow" },
+]
 
 [package.metadata]
 
@@ -520,4 +1321,60 @@ dev = [
     { name = "ruff", specifier = ">=0.14.11" },
     { name = "ty", specifier = ">=0.0.11" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
+]
+docs = [
+    { name = "cairosvg", specifier = ">=2.7" },
+    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.27" },
+    { name = "pillow", specifier = ">=10.0" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390, upload-time = "2024-11-01T14:06:24.793Z" },
+    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389, upload-time = "2024-11-01T14:06:27.112Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020, upload-time = "2024-11-01T14:06:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902, upload-time = "2024-11-01T14:06:53.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380, upload-time = "2024-11-01T14:06:55.19Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]


### PR DESCRIPTION
This pull request introduces comprehensive improvements to the documentation infrastructure and content for the `unwrappy` project. It adds a new GitHub Actions workflow for building and deploying documentation, enhances the API reference with detailed auto-generated docs, and provides a thorough architectural overview. The `README.md` is also updated with branding and status badges for better project visibility.

**Documentation Infrastructure:**

* Added a new GitHub Actions workflow (`.github/workflows/docs.yml`) to automatically build and deploy documentation on pushes to `main` and relevant changes, including support for Python 3.12 and system dependencies for generating social cards.

**API Documentation:**

* Introduced detailed API reference pages for both `Result` and `Option` types, including type aliases, class methods, utility functions, type guards, and exceptions in `docs/api/result.md` and `docs/api/option.md`. [[1]](diffhunk://#diff-7cdde730e559333047e8355e4149e5649252804f3011b08a9e9448f9b7bdf39fR1-R161) [[2]](diffhunk://#diff-8c22e79902c5856752122651e07dbcd704c25573a5670c1a7746fd8c68818306R1-R144)
* Added a new API index page (`docs/api/index.md`) summarizing all modules, quick references, and serialization utilities for easy navigation.

**Project Overview and Architecture:**

* Added a comprehensive architecture document (`docs/architecture.md`) explaining the design philosophy, type system, and comparison with similar libraries, as well as implementation decisions and performance considerations.

**Branding and Project Metadata:**

* Updated `README.md` to include a project logo (with dark/light theme support) and status badges for PyPI, Python version, license, and test workflow.